### PR TITLE
#43 fix: free tierではpreDeployCommand非対応のためstartCommandにdb:migrateを戻す

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,8 +10,7 @@ services:
       bundle install &&
       unset RAILS_MASTER_KEY &&
       SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
-    preDeployCommand: bundle exec rails db:migrate
-    startCommand: bundle exec puma -C config/puma.rb
+    startCommand: bundle exec rails db:migrate && bundle exec puma -C config/puma.rb
     healthCheckPath: /up
     envVars:
       - key: RAILS_ENV


### PR DESCRIPTION
## 概要

Closes #43 の修正対応

## 問題

Render free tier では `preDeployCommand` がサポートされていないため、以下のエラーが発生していた:

```
services[0]
pre-deploy command is not supported for free tier services
```

## 修正内容

`preDeployCommand` を削除し、`db:migrate` を `startCommand` に戻した:

```yaml
# 修正前
preDeployCommand: bundle exec rails db:migrate
startCommand: bundle exec puma -C config/puma.rb

# 修正後
startCommand: bundle exec rails db:migrate && bundle exec puma -C config/puma.rb
```