### PR TITLE
#134 Renderビルド失敗（logger初期化順序）の修正

### DIFF
--- a/.steering/20260503-issue134-render-build-fix/design.md
+++ b/.steering/20260503-issue134-render-build-fix/design.md
@@ -1,0 +1,98 @@
+# 設計書
+
+## アーキテクチャ概要
+
+Rails標準の環境設定レイヤーである`config/environments/production.rb`のみを最小変更する。`SENDGRID_API_KEY`未設定時のログ出力を、logger初期化順序に依存しない方法へ置き換える。
+
+```text
+production.rb
+	├─ config.logger (初期化)
+	├─ sendgrid_api_key 判定
+	│   ├─ present? : SMTP設定
+	│   └─ blank?   : perform_deliveries=false + 安全な警告出力
+	└─ 以降の環境設定
+```
+
+## コンポーネント設計
+
+### 1. production環境設定 (`config/environments/production.rb`)
+
+責務:
+- 本番時のActionMailer/SMTP設定を管理
+- 環境変数未設定時の安全なフォールバックを提供
+
+実装の要点:
+- `Rails.logger.warn`は初期化順序依存があるため使用しない
+- `warn`（Kernel）による標準エラー出力を用い、起動失敗を防ぐ
+
+### 2. 検証コマンド
+
+責務:
+- 既知の再現手順で回帰を検証
+- 既存テスト・lintで副作用を確認
+
+実装の要点:
+- Issue記載コマンドをそのまま実行
+- プロジェクト規約に従い`bundle exec rspec`と`bundle exec rubocop`を実行
+
+## データフロー
+
+### SENDGRID_API_KEY 未設定時
+```text
+1. production.rb読み込み
+2. sendgrid_api_keyがblank
+3. action_mailer.perform_deliveries=false
+4. warnで警告出力
+5. 起動継続 -> assets:precompile成功
+```
+
+## エラーハンドリング戦略
+
+### エラーハンドリングパターン
+
+- loggerオブジェクトへの依存を避け、初期化前でも使える出力関数を利用する
+- フェイルセーフとしてメール配信のみ無効化し、アプリ全体は停止させない
+
+## テスト戦略
+
+### ユニット/静的検証
+- `bundle exec rspec`
+- `bundle exec rubocop`
+
+### 統合検証
+- `unset RAILS_MASTER_KEY && SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile`
+
+## 依存ライブラリ
+
+新規追加なし。
+
+## ディレクトリ構造
+
+```text
+変更:
+- config/environments/production.rb
+
+作業記録:
+- .steering/20260503-issue134-render-build-fix/requirements.md
+- .steering/20260503-issue134-render-build-fix/design.md
+- .steering/20260503-issue134-render-build-fix/tasklist.md
+```
+
+## 実装の順序
+
+1. production.rbの警告出力を安全化
+2. 再現コマンドでビルド成功を確認
+3. RSpec/RuboCopで回帰確認
+
+## セキュリティ考慮事項
+
+- APIキー未設定時にキー値をログ出力しない
+- 警告文は設定不足のみを示し、機密情報は含めない
+
+## パフォーマンス考慮事項
+
+- 条件分岐1箇所の変更のみで、実行性能への影響は軽微
+
+## 将来の拡張性
+
+- 将来`config.after_initialize`でアプリロガーに統一する際も、今回の変更は安全側に動作する

--- a/.steering/20260503-issue134-render-build-fix/requirements.md
+++ b/.steering/20260503-issue134-render-build-fix/requirements.md
@@ -1,0 +1,50 @@
+# 要求内容
+
+## 概要
+
+ISSUE134として、Render本番ビルド時の`assets:precompile`失敗を解消する。具体的には`config/environments/production.rb`でlogger初期化前に発生している危険なログ出力を安全化し、`SENDGRID_API_KEY`未設定でも起動継続できるようにする。
+
+## 背景
+
+`SENDGRID_API_KEY`未設定時の分岐で`Rails.logger.warn`を呼び出すと、初期化タイミングにより`Rails.logger`が`nil`となり`NoMethodError`でアプリ起動とビルドが停止する。Renderのデプロイ工程で`assets:precompile`が失敗し、継続的なデリバリーを阻害している。
+
+## 実装対象の機能
+
+### 1. production環境の安全な警告出力
+- logger未初期化でも例外を起こさない警告出力に変更する
+- `SENDGRID_API_KEY`未設定時でもActionMailer無効化で起動継続できるようにする
+
+### 2. 再現コマンドによる回帰検証
+- Issueで提示された再現コマンドを実行し、失敗しないことを確認する
+- 既存Rails規約に従いRSpec/RuboCopで副作用がないことを確認する
+
+## 受け入れ条件
+
+### production環境の安全な警告出力
+- [ ] `config/environments/production.rb`の`SENDGRID_API_KEY`未設定分岐で`NoMethodError`が発生しない
+- [ ] `SENDGRID_API_KEY`未設定時にメール送信は無効化される
+- [ ] アプリ起動時/ビルド時に処理が継続する
+
+### 再現コマンドによる回帰検証
+- [ ] `unset RAILS_MASTER_KEY && SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile` が成功する
+- [ ] `bundle exec rspec` が成功する
+- [ ] `bundle exec rubocop` が成功する
+
+## 成功指標
+
+- Renderの`assets:precompile`失敗が再発しない
+- `SENDGRID_API_KEY`未設定時でもデプロイ/起動が継続する
+
+## スコープ外
+
+以下はこのフェーズでは実装しない:
+
+- SendGrid設定値そのものの変更
+- Renderのインフラ設定変更
+- ActionMailer配信仕様の機能追加
+
+## 参照ドキュメント
+
+- `docs/product-requirements.md` - プロダクト要求定義書
+- `docs/functional-design.md` - 機能設計書
+- `docs/architecture.md` - アーキテクチャ設計書

--- a/.steering/20260503-issue134-render-build-fix/tasklist.md
+++ b/.steering/20260503-issue134-render-build-fix/tasklist.md
@@ -35,38 +35,41 @@
 ## フェーズ4: 仕上げ
 
 - [x] 実装内容の品質検証（implementation-validator）
-- [ ] コミット
-- [ ] push & PR作成
-- [ ] CI監視 (`gh pr checks --watch`)
-- [ ] 実装後の振り返りを記載
+- [x] コミット
+- [x] push & PR作成
+- [x] ~~CI監視 (`gh pr checks --watch`)~~（理由: 対象PRにGitHub Checksが設定されておらず `no checks reported` で監視不可）
+- [x] 実装後の振り返りを記載
 
 ---
 
 ## 実装後の振り返り
 
 ### 実装完了日
-{YYYY-MM-DD}
+2026-05-03
 
 ### 計画と実績の差分
 
 **計画と異なった点**:
-- {差分を記載}
+- `config/environments/production.rb` の実装は最小変更で完了し、新規コードファイルや追加テストは不要だった。
+- 既存コミット（`#134 Renderビルド失敗を修正（logger初期化順序対応）`）が存在していたため、仕上げ工程はPR作成と振り返り更新を中心に実施した。
 
 **新たに必要になったタスク**:
-- {必要に応じて記載}
+- GitHub PR作成（`#140`）
+- CI監視の実行可否確認（Checks未設定のため代替確認へ切り替え）
 
 **技術的理由でスキップしたタスク**（該当する場合のみ）:
-- {タスク名}
-	- スキップ理由: {具体的な技術的理由}
-	- 代替実装: {何に置き換わったか}
+- `gh pr checks --watch`
+	- スキップ理由: 対象ブランチにChecksが1件も紐づいておらず、コマンドが `no checks reported` で終了したため。
+	- 代替実装: PR作成完了とローカル品質検証（assets:precompile / RSpec / RuboCop）の成功結果を最終確認に採用。
 
 ### 学んだこと
 
 **技術的な学び**:
-- {学びを記載}
+- Rails本番設定読み込み中は `Rails.logger` の初期化順序に依存する。環境分岐の警告は `warn` を使うと初期化前でも安全に出力できる。
+- Render向けの再現は `unset RAILS_MASTER_KEY && SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile` が有効な回帰チェックとなる。
 
 **プロセス上の改善点**:
-- {改善点を記載}
+- 仕上げ工程（push/PR/CI監視/振り返り）のチェックボックスを、実施直後に更新する運用へ統一すると取りこぼしを防げる。
 
 ### 次回への改善提案
-- {改善提案を記載}
+- CI未設定ブランチでも失敗扱いにならないよう、`gh pr checks --watch` の前に `gh pr view --json statusCheckRollup` でchecks有無を判定する補助手順を追加する。

--- a/.steering/20260503-issue134-render-build-fix/tasklist.md
+++ b/.steering/20260503-issue134-render-build-fix/tasklist.md
@@ -1,0 +1,72 @@
+# タスクリスト
+
+## 🚨 タスク完全完了の原則
+
+このファイルの全タスクが完了するまで作業を継続すること。
+
+---
+
+## フェーズ1: 要因特定と修正
+
+- [x] ISSUE134の再現確認
+	- [x] Issue記載の再現コマンドで失敗を確認
+	- [x] 失敗箇所が`config/environments/production.rb`であることを確認
+
+- [x] production.rb の修正
+	- [x] logger初期化前でも安全な警告出力へ変更
+	- [x] `SENDGRID_API_KEY`未設定時に起動継続することを確認
+
+## フェーズ2: 検証
+
+- [x] ISSUE再現コマンドで成功確認
+	- [x] `unset RAILS_MASTER_KEY && SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile`
+
+- [x] プロジェクト標準の品質チェック
+	- [x] `bundle exec rspec`
+	- [x] `bundle exec rubocop`
+
+## フェーズ3: プロンプト要求の追加検証
+
+- [x] add-feature.prompt.md 指定コマンドの実行結果を確認
+	- [x] ~~`npm test`~~（理由: Railsアプリ構成で`package.json`に`test` scriptが存在しないため実行不可）
+	- [x] ~~`npm run lint`~~（理由: Railsアプリ構成で`package.json`に`lint` scriptが存在しないため実行不可）
+	- [x] ~~`npm run typecheck`~~（理由: Railsアプリ構成で`package.json`に`typecheck` scriptが存在しないため実行不可）
+
+## フェーズ4: 仕上げ
+
+- [x] 実装内容の品質検証（implementation-validator）
+- [ ] コミット
+- [ ] push & PR作成
+- [ ] CI監視 (`gh pr checks --watch`)
+- [ ] 実装後の振り返りを記載
+
+---
+
+## 実装後の振り返り
+
+### 実装完了日
+{YYYY-MM-DD}
+
+### 計画と実績の差分
+
+**計画と異なった点**:
+- {差分を記載}
+
+**新たに必要になったタスク**:
+- {必要に応じて記載}
+
+**技術的理由でスキップしたタスク**（該当する場合のみ）:
+- {タスク名}
+	- スキップ理由: {具体的な技術的理由}
+	- 代替実装: {何に置き換わったか}
+
+### 学んだこと
+
+**技術的な学び**:
+- {学びを記載}
+
+**プロセス上の改善点**:
+- {改善点を記載}
+
+### 次回への改善提案
+- {改善提案を記載}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
     }
   else
     config.action_mailer.perform_deliveries = false
-    Rails.logger.warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
+    warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
   end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
## 概要
Renderの`assets:precompile`で発生していた`NoMethodError (undefined method `warn` for nil:NilClass)`を解消しました。

## 変更内容
- `config/environments/production.rb` の `SENDGRID_API_KEY` 未設定分岐で `Rails.logger.warn` を `warn` に変更
- logger初期化前でも安全に警告を出しつつ、`perform_deliveries=false`で起動継続
- `.steering/20260503-issue134-render-build-fix/` に要件・設計・タスクリストを記録

## 検証結果
- `unset RAILS_MASTER_KEY && SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile` : 成功
- `bundle exec rspec` : 308 examples, 0 failures
- `bundle exec rubocop` : 69 files, no offenses

Closes #134