### PR TITLE
#145 タイトル検索の書影URLをGoogle Books thumbnailに変更

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -136,12 +136,12 @@ class BooksController < ApplicationController
 
     items.map do |item|
       info = item["volumeInfo"]
-      isbn = extract_isbn_from_identifiers(info["industryIdentifiers"])
+      thumbnail = info.dig("imageLinks", "thumbnail").to_s.sub("http://", "https://")
       {
         title: info["title"].to_s,
         author: Array(info["authors"]).join(", "),
         total_pages: info["pageCount"],
-        cover_image_url: isbn ? "https://cover.openbd.jp/#{isbn}.jpg" : ""
+        cover_image_url: thumbnail
       }
     end
   end

--- a/spec/requests/books_search_spec.rb
+++ b/spec/requests/books_search_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe 'Books Search', type: :request do
             'pageCount' => 260,
             'industryIdentifiers' => [
               { 'type' => 'ISBN_13', 'identifier' => '9784873115658' }
-            ]
+            ],
+            'imageLinks' => {
+              'thumbnail' => 'http://books.google.com/books/content?id=abc&printsec=frontcover&img=1'
+            }
           }
         },
         {
@@ -172,10 +175,18 @@ RSpec.describe 'Books Search', type: :request do
           expect(book['title']).to eq('リーダブルコード')
           expect(book['author']).to eq('Dustin Boswell, Trevor Foucher')
           expect(book['total_pages']).to eq(260)
-          expect(book['cover_image_url']).to eq('https://cover.openbd.jp/9784873115658.jpg')
+          expect(book['cover_image_url']).to eq('https://books.google.com/books/content?id=abc&printsec=frontcover&img=1')
         end
 
-        it 'ISBN不明の候補は書影URLが空文字' do
+        it '書影URLのhttp:// は https:// に変換される' do
+          get search_books_path, params: { q: 'リーダブルコード' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to start_with('https://')
+        end
+
+        it 'imageLinksがない候補は書影URLが空文字' do
           get search_books_path, params: { q: 'リーダブルコード' }
 
           json = JSON.parse(response.body)

--- a/spec/system/books/isbn_autofetch_spec.rb
+++ b/spec/system/books/isbn_autofetch_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe 'タイトル入力からのISBN・書影自動取得', type: :sy
             'pageCount' => 260,
             'industryIdentifiers' => [
               { 'type' => 'ISBN_13', 'identifier' => '9784873115658' }
-            ]
+            ],
+            'imageLinks' => {
+              'thumbnail' => 'http://books.google.com/books/content?id=test&zoom=1'
+            }
           }
         }
       ]
@@ -81,7 +84,7 @@ RSpec.describe 'タイトル入力からのISBN・書影自動取得', type: :sy
 
       expect(page).to have_field('著者', with: 'Dustin Boswell', wait: 5)
       expect(page).to have_field('総ページ数', with: '260', wait: 5)
-      expect(page).to have_field('書影URL', with: 'https://cover.openbd.jp/9784873115658.jpg', wait: 5)
+      expect(page).to have_field('書影URL', with: 'https://books.google.com/books/content?id=test&zoom=1', wait: 5)
     end
 
     it '自動取得成功時はISBNフォールバックセクションが非表示のまま' do


### PR DESCRIPTION
## 概要
タイトル検索（Google Books API）で取得した書籍の書影URLが404になる問題を修正しました。

## 原因
`search_by_title` はISBNを取り出してOpenBD URLを構築していたが、Google BooksにあってOpenBDにない書籍ではURLが404になる。

## 修正内容
- `search_by_title` でOpenBD URL構築を廃止し、Google Books APIの`imageLinks.thumbnail`を直接使用するように変更
- thumbnailのURLは`http://`を`https://`に変換
- 対応テストを更新（`imageLinks`なし→空文字、`imageLinks`あり→https変換済みURLを期待）

## 変更ファイル
- `app/controllers/books_controller.rb`
- `spec/requests/books_search_spec.rb`

## テスト結果
- bundle exec rspec: 328 examples, 0 failures
- bundle exec rubocop: 72 files inspected, no offenses detected

Closes #145