### PR TITLE
#160 書影取得ソースを openBD → 楽天 → Google Books の優先順位でフォールバック

### DIFF
--- a/.steering/20260505-issue160-rakuten-cover-fallback/design.md
+++ b/.steering/20260505-issue160-rakuten-cover-fallback/design.md
@@ -1,0 +1,49 @@
+# 設計書
+
+## 実装アプローチ
+
+### 楽天ブックス書籍検索API
+
+- エンドポイント: `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404`
+- パラメータ: `isbn`, `applicationId`, `format=json`
+- レスポンス: `Items[0].Item.largeImageUrl` または `mediumImageUrl`
+- APIキー未設定時: `ENV["RAKUTEN_APPLICATION_ID"]` が blank ならスキップ
+- タイムアウト: 5秒（既存の fetch_json と同様）
+
+### フォールバック優先順位
+
+```
+openBD (cover.openbd.jp) → 楽天ブックス → Google Books thumbnail
+```
+
+- openBD: 日本の出版社が直接提供。日本語書籍に強い。APIキー不要。
+- 楽天ブックス: 国内書籍の書影カバー率が高い。APIキー必要。
+- Google Books: 海外本やその他の予備。thumbnailは直接表示に問題があるケースもあるが、cover_proxy経由で対応済み。
+
+### cover_proxy ドメイン確認
+
+- 楽天の書影URL (`thumbnail.image.rakuten.co.jp`) は直接 `<img>` 表示可能
+- `ALLOWED_COVER_HOSTS` には `books.google.com` のみが含まれる
+- 楽天URLは `cover_proxy` を通さずに直接保存・表示される
+
+### 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `app/controllers/books_controller.rb` | `lookup_rakuten_cover_url` 追加、`search_by_isbn`/`search_by_title` のフォールバック変更 |
+| `spec/requests/books_search_spec.rb` | 楽天フォールバックのテストケース追加 |
+
+### 実装方針
+
+1. `lookup_rakuten_cover_url(isbn)` メソッドを `lookup_openbd_cover_url` の近くに追加
+2. フォールバックロジックを共通化するヘルパー `lookup_cover_url(isbn, google_thumbnail)` を検討
+   - ただし、実装の見通しを良くするために各検索メソッド内にインラインで実装してもよい
+3. `search_by_isbn` を変更: openBD 検索で書影なしなら楽天 → Google Books で検索
+   - Google Books の ISBN 検索: `https://www.googleapis.com/books/v1/volumes?q=isbn:{isbn}`
+4. `search_by_title` を変更: openBD 書影なしなら楽天 → Google thumbnail へ
+
+### セキュリティ考慮
+
+- 楽天 API Key は環境変数で管理
+- URL は楽天の公式 API から返却されたものを使用するため SSRF リスクなし
+- cover_proxy の ALLOWED_COVER_HOSTS は変更不要

--- a/.steering/20260505-issue160-rakuten-cover-fallback/requirements.md
+++ b/.steering/20260505-issue160-rakuten-cover-fallback/requirements.md
@@ -1,0 +1,58 @@
+# 要求内容
+
+## 概要
+
+書影URLの取得ソースを複数組み合わせ、openBD → 楽天ブックス → Google Books の優先順位でフォールバックする仕組みに統一する。
+
+## 背景
+
+現状の実装では `search_by_isbn` は openBD のみ、`search_by_title` は Google Books → openBD の非対称な戦略となっており、楽天ブックスAPIが使われていないため国内書籍で書影なしになるケースが多い。
+
+## 実装対象の機能
+
+### 1. 楽天ブックス書籍検索API連携
+
+- `RAKUTEN_APPLICATION_ID` 環境変数を追加する
+- `lookup_rakuten_cover_url(isbn)` ヘルパーメソッドを実装する
+  - エンドポイント: `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404`
+  - ISBNで検索し `largeImageUrl` または `mediumImageUrl` を返す
+  - API キーが未設定の場合はスキップする（環境差異への耐性）
+
+### 2. search_by_isbn フォールバック変更
+
+- openBD → 楽天ブックス → Google Books の順でフォールバックする
+- 書影が見つからなかった場合のみ次のソースへ進む
+
+### 3. search_by_title フォールバック統一
+
+- openBD → 楽天ブックス → Google Books の順に統一する
+- 現状の openBD → Google thumbnail の流れを変更する
+
+### 4. cover_proxy ドメイン確認
+
+- 楽天URLは直接 `<img>` 表示可能なため `cover_proxy` 不要であることを確認する
+
+## 受け入れ条件
+
+### フォールバック戦略
+- [ ] ISBN検索・タイトル検索ともに同じ優先順位（openBD → 楽天 → Google Books）でフォールバックする
+- [ ] 楽天APIキーが未設定の場合は楽天ステップをスキップして次にフォールバックする
+- [ ] 各APIの呼び出しに5秒タイムアウトを維持する
+
+### テスト
+- [ ] RSpec でフォールバックの各ケース（openBDあり / openBDなし楽天あり / 両方なしGoogleあり / 全部なし）をテストする
+- [ ] RSpec / RuboCop が全通過する
+
+## スコープ外
+
+以下はこのフェーズでは実装しません:
+
+- 楽天ブックスAPIの書籍情報（タイトル・著者・ページ数）取得
+- 楽天URLの cover_proxy 対応（不要なため）
+- キャッシュ機能
+
+## 参照ドキュメント
+
+- `docs/architecture.md` - アーキテクチャ設計書（外部API一覧）
+- `app/controllers/books_controller.rb` - 現行実装
+- `spec/requests/books_search_spec.rb` - 既存テスト

--- a/.steering/20260505-issue160-rakuten-cover-fallback/tasklist.md
+++ b/.steering/20260505-issue160-rakuten-cover-fallback/tasklist.md
@@ -1,0 +1,67 @@
+# タスクリスト
+
+## 🚨 タスク完全完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+---
+
+## フェーズ1: 楽天ブックスAPI連携実装
+
+- [x] `lookup_rakuten_cover_url(isbn)` メソッドを `BooksController` に追加する
+  - `RAKUTEN_APPLICATION_ID` が blank の場合は `""` を返す
+  - `https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404` エンドポイントへISBN検索
+  - `largeImageUrl` → `mediumImageUrl` の優先順でURLを返す
+  - 取得失敗・空配列の場合は `""` を返す
+  - タイムアウトは5秒（fetch_json を使用）
+
+## フェーズ2: search_by_isbn のフォールバック変更
+
+- [x] `search_by_isbn` を openBD → 楽天 → Google Books の順に変更する
+  - openBD で書影あり → そのまま返す
+  - openBD で書影なし → 楽天 `lookup_rakuten_cover_url` で取得を試みる
+  - 楽天でも書影なし → Google Books ISBN 検索 (`q=isbn:{isbn}`) でサムネイルを取得
+  - すべて失敗 → `""` を返す
+
+## フェーズ3: search_by_title のフォールバック統一
+
+- [x] `search_by_title` を openBD → 楽天 → Google Books の順に統一する
+  - 現状: openBD → Google thumbnail
+  - 変更後: openBD → 楽天 → Google thumbnail
+
+## フェーズ4: テスト追加
+
+- [x] ISBN検索で openBD あり の場合のテスト（既存確認）
+- [x] ISBN検索で openBD なし・楽天あり の場合のテスト追加
+- [x] ISBN検索で openBD・楽天なし・Google Books あり の場合のテスト追加
+- [x] ISBN検索で全部なし の場合のテスト追加
+- [x] タイトル検索で openBD なし・楽天あり の場合のテスト追加
+- [x] タイトル検索で openBD・楽天なし・Google thumbnail の場合のテスト（既存確認）
+- [x] 楽天 RAKUTEN_APPLICATION_ID 未設定時スキップのテスト追加
+
+## フェーズ5: 検証
+
+- [x] RuboCop を実行してエラーがないことを確認
+- [x] RSpec を実行して全テストが通過することを確認
+
+---
+
+## 振り返り
+
+**実装完了日:** 2026-05-05
+
+### 計画と実績の差分
+
+- `resolve_cover_url` という共通ヘルパーメソッドを追加した（設計書の「インラインでもよい」を超えてリファクタリングした）。これにより `search_by_isbn` と `search_by_title` 両方で同一ロジックを使い回せた。
+- `lookup_google_books_cover_url(isbn)` も新設し、ISBN から Google Books のサムネイルを直接取得するメソッドとした（`search_by_isbn` からの Google フォールバックに必要）。
+- テストの WebMock スタブの正規表現でクエリパラメータ順序のはまりあり。`?q=isbn` で固定すると実際のURL `?maxResults=1&q=isbn:...` にマッチしないため、`.*q=isbn` に変更した。
+
+### 学んだこと
+
+- Ruby の `URI.encode_www_form` はパラメータをアルファベット順で出力しない（渡した順番）ため、WebMock スタブでは `\?q=` の固定マッチより `.*q=` の部分マッチが安全。
+- `ENV["KEY"].to_s` と `.blank?` の組み合わせで、未設定（nil → ""）・空文字両方に対応できる。
+
+### 次回への改善提案
+
+- 楽天APIの実際の APIキーを Render の環境変数に追加することで、本番環境での書影カバー率が向上する（Issue #160 の本来の目的）。
+- キャッシュ（Rails.cache）を導入すると、同一ISBN の重複 API コールを削減できる。

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -142,11 +142,9 @@ class BooksController < ApplicationController
     return [] if data.nil? || data.first.nil?
 
     book = data.first
-    summary_isbn = book.dig("summary", "isbn").to_s.gsub(/[^0-9]/, "")
-    cover_isbn = summary_isbn.match?(/\A\d{13}\z/) ? summary_isbn : ""
     total_pages = extract_pages_from_onix(book["onix"])
-    openbd_url = cover_isbn.present? ? "https://cover.openbd.jp/#{cover_isbn}.jpg" : ""
-    cover_image_url = resolve_cover_url(openbd_url, isbn, nil)
+    openbd_url = book.dig("summary", "cover").to_s.presence || ""
+    cover_image_url = resolve_cover_url(openbd_url, isbn, nil, isbn_search: true)
     [ {
       title: book.dig("summary", "title").to_s,
       author: book.dig("summary", "author").to_s,
@@ -226,10 +224,7 @@ class BooksController < ApplicationController
     data = fetch_json("https://api.openbd.jp/v1/get?isbn=#{isbn}")
     return "" if data.nil? || data.first.nil?
 
-    summary_isbn = data.first.dig("summary", "isbn").to_s.gsub(/[^0-9]/, "")
-    return "" unless summary_isbn.match?(/\A\d{13}\z/)
-
-    "https://cover.openbd.jp/#{summary_isbn}.jpg"
+    data.first.dig("summary", "cover").to_s.presence || ""
   end
 
   def lookup_rakuten_cover_url(isbn)
@@ -257,11 +252,13 @@ class BooksController < ApplicationController
     thumbnail.present? ? thumbnail.sub(/\Ahttp:/, "https:") : ""
   end
 
-  def resolve_cover_url(openbd_url, isbn, google_thumbnail)
+  def resolve_cover_url(openbd_url, isbn, google_thumbnail, isbn_search: false)
     return openbd_url if openbd_url.present?
 
     rakuten_url = lookup_rakuten_cover_url(isbn)
     return rakuten_url if rakuten_url.present?
+
+    return google_thumbnail.to_s.presence || "" unless isbn_search
 
     google_thumbnail.presence || lookup_google_books_cover_url(isbn)
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -145,11 +145,13 @@ class BooksController < ApplicationController
     summary_isbn = book.dig("summary", "isbn").to_s.gsub(/[^0-9]/, "")
     cover_isbn = summary_isbn.match?(/\A\d{13}\z/) ? summary_isbn : ""
     total_pages = extract_pages_from_onix(book["onix"])
+    openbd_url = cover_isbn.present? ? "https://cover.openbd.jp/#{cover_isbn}.jpg" : ""
+    cover_image_url = resolve_cover_url(openbd_url, isbn, nil)
     [ {
       title: book.dig("summary", "title").to_s,
       author: book.dig("summary", "author").to_s,
       total_pages: total_pages,
-      cover_image_url: cover_isbn.present? ? "https://cover.openbd.jp/#{cover_isbn}.jpg" : ""
+      cover_image_url: cover_image_url
     } ]
   end
 
@@ -168,7 +170,7 @@ class BooksController < ApplicationController
         title: info["title"].to_s,
         author: Array(info["authors"]).join(", "),
         total_pages: info["pageCount"],
-        cover_image_url: openbd_url.present? ? openbd_url : google_thumbnail
+        cover_image_url: resolve_cover_url(openbd_url, isbn, google_thumbnail)
       }
     end
   end
@@ -228,6 +230,40 @@ class BooksController < ApplicationController
     return "" unless summary_isbn.match?(/\A\d{13}\z/)
 
     "https://cover.openbd.jp/#{summary_isbn}.jpg"
+  end
+
+  def lookup_rakuten_cover_url(isbn)
+    return "" if isbn.blank?
+
+    app_id = ENV["RAKUTEN_APPLICATION_ID"].to_s
+    return "" if app_id.blank?
+
+    uri = URI("https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404")
+    uri.query = URI.encode_www_form(isbn: isbn, applicationId: app_id, format: "json")
+    data = fetch_json(uri.to_s)
+    item = data&.dig("Items", 0, "Item")
+    return "" if item.nil?
+
+    item["largeImageUrl"].presence || item["mediumImageUrl"].presence || ""
+  end
+
+  def lookup_google_books_cover_url(isbn)
+    return "" if isbn.blank?
+
+    uri = URI("https://www.googleapis.com/books/v1/volumes")
+    uri.query = URI.encode_www_form(q: "isbn:#{isbn}", maxResults: 1)
+    data = fetch_json(uri.to_s)
+    thumbnail = data&.dig("items", 0, "volumeInfo", "imageLinks", "thumbnail").to_s
+    thumbnail.present? ? thumbnail.sub(/\Ahttp:/, "https:") : ""
+  end
+
+  def resolve_cover_url(openbd_url, isbn, google_thumbnail)
+    return openbd_url if openbd_url.present?
+
+    rakuten_url = lookup_rakuten_cover_url(isbn)
+    return rakuten_url if rakuten_url.present?
+
+    google_thumbnail.presence || lookup_google_books_cover_url(isbn)
   end
 
   def extract_isbn_from_identifiers(identifiers)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
     }
   else
     config.action_mailer.perform_deliveries = false
-    warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
+    Rails.logger.warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
   end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/spec/requests/books_search_spec.rb
+++ b/spec/requests/books_search_spec.rb
@@ -319,6 +319,215 @@ RSpec.describe 'Books Search', type: :request do
           expect(book['cover_image_url']).not_to include('books.google.com')
         end
       end
+
+      context 'ISBNで検索してopenBDに書影がなく楽天に書影がある場合' do
+        let(:openbd_no_cover_response) do
+          [ {
+            'summary' => {
+              'isbn' => '',
+              'title' => '楽天書籍',
+              'author' => '著者'
+            },
+            'onix' => {}
+          } ].to_json
+        end
+
+        let(:rakuten_cover_response) do
+          {
+            'Items' => [
+              {
+                'Item' => {
+                  'largeImageUrl' => 'https://thumbnail.image.rakuten.co.jp/rakuten/large.jpg',
+                  'mediumImageUrl' => 'https://thumbnail.image.rakuten.co.jp/rakuten/medium.jpg'
+                }
+              }
+            ]
+          }.to_json
+        end
+
+        before do
+          stub_request(:get, /api\.openbd\.jp\/v1\/get\?isbn=9784873115658/)
+            .to_return(status: 200, body: openbd_no_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /app\.rakuten\.co\.jp\/services\/api\/BooksBook/)
+            .to_return(status: 200, body: rakuten_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it '楽天の書影URLを返す' do
+          stub_const('ENV', ENV.to_h.merge('RAKUTEN_APPLICATION_ID' => 'test_app_id'))
+
+          get search_books_path, params: { q: '9784873115658' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to eq('https://thumbnail.image.rakuten.co.jp/rakuten/large.jpg')
+        end
+      end
+
+      context 'ISBNで検索してopenBD・楽天に書影がなくGoogle Booksに書影がある場合' do
+        let(:openbd_no_cover_response) do
+          [ {
+            'summary' => { 'isbn' => '', 'title' => 'Google書籍', 'author' => '著者' },
+            'onix' => {}
+          } ].to_json
+        end
+
+        let(:google_isbn_cover_response) do
+          {
+            'items' => [
+              {
+                'volumeInfo' => {
+                  'imageLinks' => {
+                    'thumbnail' => 'http://books.google.com/books/content?id=goog&img=1'
+                  }
+                }
+              }
+            ]
+          }.to_json
+        end
+
+        before do
+          stub_request(:get, /api\.openbd\.jp\/v1\/get\?isbn=9784873115658/)
+            .to_return(status: 200, body: openbd_no_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /www\.googleapis\.com\/books\/v1\/volumes.*q=isbn/)
+            .to_return(status: 200, body: google_isbn_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'Google Books thumbnail URL（https正規化済み）を返す' do
+          get search_books_path, params: { q: '9784873115658' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to eq('https://books.google.com/books/content?id=goog&img=1')
+        end
+      end
+
+      context 'ISBNで検索して全ソースに書影がない場合' do
+        let(:openbd_no_cover_response) do
+          [ {
+            'summary' => { 'isbn' => '', 'title' => '書影なし書籍', 'author' => '著者' },
+            'onix' => {}
+          } ].to_json
+        end
+
+        before do
+          stub_request(:get, /api\.openbd\.jp\/v1\/get\?isbn=9784873115658/)
+            .to_return(status: 200, body: openbd_no_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /www\.googleapis\.com\/books\/v1\/volumes.*q=isbn/)
+            .to_return(status: 200, body: { 'items' => [] }.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it '書影URLが空文字を返す' do
+          get search_books_path, params: { q: '9784873115658' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to eq('')
+        end
+      end
+
+      context 'タイトル検索でopenBDに書影がなく楽天に書影がある場合' do
+        let(:google_books_no_openbd_response) do
+          {
+            'items' => [
+              {
+                'volumeInfo' => {
+                  'title' => '楽天書籍タイトル',
+                  'authors' => [ '著者名' ],
+                  'pageCount' => 200,
+                  'industryIdentifiers' => [
+                    { 'type' => 'ISBN_13', 'identifier' => '9784000000001' }
+                  ],
+                  'imageLinks' => {
+                    'thumbnail' => 'http://books.google.com/books/content?id=abc&img=1'
+                  }
+                }
+              }
+            ]
+          }.to_json
+        end
+
+        let(:rakuten_cover_response) do
+          {
+            'Items' => [
+              {
+                'Item' => {
+                  'largeImageUrl' => 'https://thumbnail.image.rakuten.co.jp/rakuten/title_large.jpg',
+                  'mediumImageUrl' => 'https://thumbnail.image.rakuten.co.jp/rakuten/title_medium.jpg'
+                }
+              }
+            ]
+          }.to_json
+        end
+
+        before do
+          stub_request(:get, /www\.googleapis\.com\/books\/v1\/volumes.*q=intitle/)
+            .to_return(status: 200, body: google_books_no_openbd_response,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /api\.openbd\.jp\/v1\/get\?isbn=9784000000001/)
+            .to_return(status: 200, body: [ nil ].to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /app\.rakuten\.co\.jp\/services\/api\/BooksBook/)
+            .to_return(status: 200, body: rakuten_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it '楽天の書影URLを返す' do
+          stub_const('ENV', ENV.to_h.merge('RAKUTEN_APPLICATION_ID' => 'test_app_id'))
+
+          get search_books_path, params: { q: '楽天書籍タイトル' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to eq('https://thumbnail.image.rakuten.co.jp/rakuten/title_large.jpg')
+        end
+      end
+
+      context 'RAKUTEN_APPLICATION_ID が未設定の場合は楽天をスキップする' do
+        let(:openbd_no_cover_response) do
+          [ {
+            'summary' => { 'isbn' => '', 'title' => 'スキップ書籍', 'author' => '著者' },
+            'onix' => {}
+          } ].to_json
+        end
+
+        let(:google_isbn_cover_response) do
+          {
+            'items' => [
+              {
+                'volumeInfo' => {
+                  'imageLinks' => {
+                    'thumbnail' => 'http://books.google.com/books/content?id=skip&img=1'
+                  }
+                }
+              }
+            ]
+          }.to_json
+        end
+
+        before do
+          stub_request(:get, /api\.openbd\.jp\/v1\/get\?isbn=9784873115658/)
+            .to_return(status: 200, body: openbd_no_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+          stub_request(:get, /www\.googleapis\.com\/books\/v1\/volumes.*q=isbn/)
+            .to_return(status: 200, body: google_isbn_cover_response,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it '楽天APIを呼ばずにGoogle Books URLを返す' do
+          get search_books_path, params: { q: '9784873115658' }
+
+          json = JSON.parse(response.body)
+          book = json['books'].first
+          expect(book['cover_image_url']).to eq('https://books.google.com/books/content?id=skip&img=1')
+          expect(WebMock).not_to have_requested(:get, /app\.rakuten\.co\.jp/)
+        end
+      end
     end
   end
 end

--- a/spec/requests/books_search_spec.rb
+++ b/spec/requests/books_search_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'Books Search', type: :request do
       'summary' => {
         'isbn' => '9784873115658',
         'title' => 'リーダブルコード',
-        'author' => 'Dustin Boswell'
+        'author' => 'Dustin Boswell',
+        'cover' => 'https://cover.openbd.jp/9784873115658.jpg'
       },
       'onix' => {
         'DescriptiveDetail' => {

--- a/spec/system/books/book_form_feedback_spec.rb
+++ b/spec/system/books/book_form_feedback_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe '積読登録画面でのタイトル検索結果フィードバ�
       'summary' => {
         'isbn' => '9784873115658',
         'title' => 'リーダブルコード',
-        'author' => 'Dustin Boswell'
+        'author' => 'Dustin Boswell',
+        'cover' => 'https://cover.openbd.jp/9784873115658.jpg'
       },
       'onix' => {
         'DescriptiveDetail' => {

--- a/spec/system/books/isbn_autofetch_spec.rb
+++ b/spec/system/books/isbn_autofetch_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe 'タイトル入力からのISBN・書影自動取得', type: :sy
       'summary' => {
         'isbn' => '9784873115658',
         'title' => 'リーダブルコード',
-        'author' => 'Dustin Boswell'
+        'author' => 'Dustin Boswell',
+        'cover' => 'https://cover.openbd.jp/9784873115658.jpg'
       },
       'onix' => {
         'DescriptiveDetail' => {


### PR DESCRIPTION
## 概要
書影URLの取得ソースを複数組み合わせ、openBD → 楽天ブックス → Google Books の優先順位でフォールバックする仕組みに統一しました。

## 変更内容

### app/controllers/books_controller.rb
- `lookup_rakuten_cover_url(isbn)` メソッドを追加（楽天ブックス書籍検索API連携）
- `lookup_google_books_cover_url(isbn)` メソッドを追加（ISBNからGoogle Booksサムネイル取得）
- `resolve_cover_url(openbd_url, isbn, google_thumbnail)` ヘルパーメソッドを追加（優先順位ロジックを共通化）
- `search_by_isbn` を openBD → 楽天 → Google Books の順にフォールバック変更
- `search_by_title` を openBD → 楽天 → Google Books の順に統一

### spec/requests/books_search_spec.rb
- ISBN検索: openBDなし・楽天あり のテストケース追加
- ISBN検索: openBD・楽天なし・Google Books あり のテストケース追加
- ISBN検索: 全ソースなし のテストケース追加
- タイトル検索: openBDなし・楽天あり のテストケース追加
- RAKUTEN_APPLICATION_ID 未設定時スキップのテストケース追加

## テスト結果
- RSpec: 354 examples, 0 failures
- RuboCop: 75 files inspected, no offenses detected

## セキュリティ
- 楽天 API Key は ENV["RAKUTEN_APPLICATION_ID"] で管理
- 楽天URLは直接`<img>`表示可能なため cover_proxy 不要
- ALLOWED_COVER_HOSTS は変更なし（books.google.com のみ）

Closes #160