### PR TITLE
fix: production.rbのRails.logger.warnをwarnに戻す（Renderビルド失敗修正）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
     }
   else
     config.action_mailer.perform_deliveries = false
-    Rails.logger.warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
+    warn "[ActionMailer] SENDGRID_API_KEY is not set. Email delivery is disabled."
   end
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
## 概要
assets:precompile 実行時、`Rails.logger` は nil のため `Rails.logger.warn` が `NoMethodError` を起こしていた。Ruby の `Kernel#warn` （単純な `warn`）に戻す。

## 原因
- PR #161 で `warn` → `Rails.logger.warn` に変更
- Render ビルドコマンド (`SECRET_KEY_BASE_DUMMY=1 rails assets:precompile`) 実行時、`config/environments/production.rb` の設定ブロックは Rails ロガー初期化前に評価される
- `Rails.logger` が `nil` のため `NoMethodError: private method warn called for nil` が発生

## 修正内容
- `Rails.logger.warn` → `warn`（Ruby Kernel#warn）

## 確認
```
SECRET_KEY_BASE_DUMMY=1 RAILS_ENV=production bundle exec rails assets:precompile
→ 正常完了
```
- RSpec: 354 examples, 0 failures
- RuboCop: no offenses