### PR TITLE
#158 cover_proxy のHTTPリダイレクト追跡対応

### DIFF
--- a/.steering/20260505-issue158-cover-proxy-redirect/design.md
+++ b/.steering/20260505-issue158-cover-proxy-redirect/design.md
@@ -1,0 +1,69 @@
+# 設計: cover_proxy HTTPリダイレクト対応
+
+## アプローチ
+`BooksController#cover_proxy` アクションに、HTTPリダイレクト追跡ロジックを追加する。
+
+## 変更ファイル
+- `app/controllers/books_controller.rb` - `cover_proxy` アクションを修正
+- `spec/requests/cover_proxy_spec.rb` - リダイレクトケースのテストを追加
+
+## 実装詳細
+
+### ALLOWED_REDIRECT_HOSTS の追加
+```ruby
+ALLOWED_COVER_HOSTS = %w[books.google.com].freeze
+ALLOWED_REDIRECT_HOSTS = %w[books.google.com lh3.googleusercontent.com].freeze
+MAX_REDIRECTS = 3
+```
+
+### cover_proxy アクション修正
+`Net::HTTPRedirection` を検出し、`Location` ヘッダーのURLにリダイレクトする。
+リダイレクト先は `ALLOWED_REDIRECT_HOSTS` に含まれるドメインに限定する。
+
+```ruby
+def cover_proxy
+  url = params[:url].to_s
+  uri = URI.parse(url)
+  return head :forbidden unless ALLOWED_COVER_HOSTS.include?(uri.host)
+
+  response = fetch_with_redirects(uri)
+  return head :not_found if response.nil?
+
+  content_type = response["content-type"] || "image/jpeg"
+  send_data response.body, type: content_type, disposition: "inline"
+rescue URI::InvalidURIError
+  head :bad_request
+rescue Net::OpenTimeout, Net::ReadTimeout
+  head :not_found
+rescue StandardError
+  head :not_found
+end
+
+private
+
+def fetch_with_redirects(uri, redirect_count = 0)
+  return nil if redirect_count > MAX_REDIRECTS
+
+  response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
+                              open_timeout: 5, read_timeout: 5) do |http|
+    http.get(uri.request_uri)
+  end
+
+  if response.is_a?(Net::HTTPRedirection)
+    location = response["location"]
+    redirect_uri = URI.parse(location)
+    return nil unless ALLOWED_REDIRECT_HOSTS.include?(redirect_uri.host)
+    fetch_with_redirects(redirect_uri, redirect_count + 1)
+  elsif response.is_a?(Net::HTTPSuccess)
+    response
+  else
+    nil
+  end
+end
+```
+
+## セキュリティ考慮事項
+- 初回リクエストは `ALLOWED_COVER_HOSTS`（`books.google.com`）のみ許可
+- リダイレクト先は `ALLOWED_REDIRECT_HOSTS`（`books.google.com`, `lh3.googleusercontent.com`）のみ許可
+- 最大リダイレクト数 3 で無限ループを防止
+- `URI::InvalidURIError` は `bad_request` で応答し、任意URIの注入を防ぐ

--- a/.steering/20260505-issue158-cover-proxy-redirect/requirements.md
+++ b/.steering/20260505-issue158-cover-proxy-redirect/requirements.md
@@ -1,0 +1,24 @@
+# 要件定義: cover_proxy HTTPリダイレクト対応
+
+## Issue
+#158 [Bug] cover_proxy がHTTPリダイレクトを追わないため書影が表示されないケースがある
+
+## 概要
+`/books/cover_proxy` エンドポイントは `Net::HTTP` でGoogle Booksに直接リクエストするが、
+`Net::HTTP` はデフォルトでHTTPリダイレクト（302等）を追わない。
+Google Books thumbnail URLがリダイレクトを返す場合、`Net::HTTPSuccess` にならず
+`head :not_found` になるため、書影が表示されない。
+
+## 再現条件
+- `cover_image_url` が `https://books.google.com/books/...` 形式のURLで、
+  かつそのURLが302リダイレクトを返すケース
+
+## 受け入れ条件
+- リダイレクトが発生するGoogle Books URLでも書影が正しく表示される
+- 許可外ドメインへのリダイレクトは `403` を返す
+- RSpec / RuboCop が全通過する
+
+## 制約
+- 許可するリダイレクト先ドメイン: `books.google.com`, `lh3.googleusercontent.com`（Google系ドメイン）
+- 無限ループ防止のため最大リダイレクト回数: 3回
+- タイムアウト: 5秒（既存の設定を維持）

--- a/.steering/20260505-issue158-cover-proxy-redirect/tasklist.md
+++ b/.steering/20260505-issue158-cover-proxy-redirect/tasklist.md
@@ -1,0 +1,34 @@
+# タスクリスト: cover_proxy HTTPリダイレクト対応
+
+## フェーズ1: 実装
+
+- [x] `ALLOWED_REDIRECT_HOSTS` 定数と `MAX_REDIRECTS` 定数を `BooksController` に追加する
+- [x] `fetch_with_redirects` プライベートメソッドを `BooksController` に実装する
+- [x] `BooksController#cover_proxy` アクションを `fetch_with_redirects` を使う形に修正する
+
+## フェーズ2: テスト追加
+
+- [x] `spec/requests/cover_proxy_spec.rb` に302リダイレクト追跡のテストケースを追加する
+  - [x] 1回リダイレクトで正常取得できるケース
+  - [x] 許可外ドメインへのリダイレクトで403を返すケース
+  - [x] 最大リダイレクト数超過で404を返すケース
+
+## フェーズ3: 検証
+
+- [x] `bundle exec rspec spec/requests/cover_proxy_spec.rb` で全テスト通過を確認する
+- [x] `bundle exec rspec` で全テスト通過を確認する
+- [x] `bundle exec rubocop` でエラーなしを確認する
+
+## 振り返り
+
+- 実装完了日: 2026-05-05
+- 計画と実績の差分:
+  - 計画通り `fetch_with_redirects` メソッドを追加し、リダイレクト追跡を実装した
+  - 許可外ドメインへのリダイレクト時のステータスコードを `404` ではなく `403` にするため、
+    `fetch_with_redirects` の戻り値として `:forbidden` シンボルを返す設計に変更した
+- 学んだこと:
+  - `Net::HTTP` はデフォルトでリダイレクトを追わないため、明示的な実装が必要
+  - SSRF対策のためリダイレクト先ドメインも許可リストで制限することが重要
+  - 無限リダイレクトループの防止には最大リダイレクト回数のカウントが必要
+- 次回への改善提案:
+  - `fetch_with_redirects` は他の用途にも使える汎用的なパターン。HTTPプロキシ系の機能が増えた場合はサービスクラスへの切り出しを検討

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,6 +5,8 @@ require "net/http"
 class BooksController < ApplicationController
   GoogleBooksApiError = Class.new(StandardError)
   ALLOWED_COVER_HOSTS = %w[books.google.com].freeze
+  ALLOWED_REDIRECT_HOSTS = %w[books.google.com lh3.googleusercontent.com].freeze
+  MAX_REDIRECTS = 3
 
   before_action :authenticate_user!
   before_action :set_book, only: [ :show, :destroy, :update_progress, :complete, :change_deadline ]
@@ -85,17 +87,16 @@ class BooksController < ApplicationController
     uri = URI.parse(url)
     return head :forbidden unless ALLOWED_COVER_HOSTS.include?(uri.host)
 
-    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
-                                                    open_timeout: 5, read_timeout: 5) do |http|
-      http.get(uri.request_uri)
+    result = fetch_with_redirects(uri)
+    case result
+    when :forbidden
+      head :forbidden
+    when Net::HTTPResponse
+      content_type = result["content-type"] || "image/jpeg"
+      send_data result.body, type: content_type, disposition: "inline"
+    else
+      head :not_found
     end
-
-    unless response.is_a?(Net::HTTPSuccess)
-      return head :not_found
-    end
-
-    content_type = response["content-type"] || "image/jpeg"
-    send_data response.body, type: content_type, disposition: "inline"
   rescue URI::InvalidURIError
     head :bad_request
   rescue Net::OpenTimeout, Net::ReadTimeout
@@ -105,6 +106,25 @@ class BooksController < ApplicationController
   end
 
   private
+
+  def fetch_with_redirects(uri, redirect_count = 0)
+    return nil if redirect_count > MAX_REDIRECTS
+
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
+                                open_timeout: 5, read_timeout: 5) do |http|
+      http.get(uri.request_uri)
+    end
+
+    if response.is_a?(Net::HTTPRedirection)
+      location = response["location"]
+      redirect_uri = URI.parse(location)
+      return :forbidden unless ALLOWED_REDIRECT_HOSTS.include?(redirect_uri.host)
+
+      fetch_with_redirects(redirect_uri, redirect_count + 1)
+    elsif response.is_a?(Net::HTTPSuccess)
+      response
+    end
+  end
 
   def set_book
     @book = current_user.books.find_by(id: params[:id])

--- a/spec/requests/cover_proxy_spec.rb
+++ b/spec/requests/cover_proxy_spec.rb
@@ -104,6 +104,69 @@ RSpec.describe 'Books Cover Proxy', type: :request do
           expect(response).to have_http_status(:not_found)
         end
       end
+
+      context '302 リダイレクトが発生する場合' do
+        let(:redirect_url) { 'https://lh3.googleusercontent.com/books/image.jpg' }
+        let(:image_body) { "\xFF\xD8\xFF\xE0fake_jpeg_data".b }
+
+        context 'Google 系ドメインへのリダイレクトの場合' do
+          before do
+            stub_request(:get, google_image_url)
+              .to_return(status: 302, headers: { 'Location' => redirect_url })
+            stub_request(:get, redirect_url)
+              .to_return(status: 200, body: image_body,
+                         headers: { 'Content-Type' => 'image/jpeg' })
+          end
+
+          it '200 OK を返す' do
+            get cover_proxy_books_path, params: { url: google_image_url }
+
+            expect(response).to have_http_status(:ok)
+          end
+
+          it 'リダイレクト先の画像データを返す' do
+            get cover_proxy_books_path, params: { url: google_image_url }
+
+            expect(response.body).to eq(image_body)
+          end
+        end
+
+        context '許可外ドメインへのリダイレクトの場合' do
+          before do
+            stub_request(:get, google_image_url)
+              .to_return(status: 302, headers: { 'Location' => 'https://evil.example.com/image.jpg' })
+          end
+
+          it '403 Forbidden を返す' do
+            get cover_proxy_books_path, params: { url: google_image_url }
+
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context '最大リダイレクト数を超える場合' do
+          let(:redirect_url2) { 'https://books.google.com/books/image2.jpg' }
+          let(:redirect_url3) { 'https://books.google.com/books/image3.jpg' }
+          let(:redirect_url4) { 'https://lh3.googleusercontent.com/final.jpg' }
+
+          before do
+            stub_request(:get, google_image_url)
+              .to_return(status: 302, headers: { 'Location' => redirect_url2 })
+            stub_request(:get, redirect_url2)
+              .to_return(status: 302, headers: { 'Location' => redirect_url3 })
+            stub_request(:get, redirect_url3)
+              .to_return(status: 302, headers: { 'Location' => redirect_url4 })
+            stub_request(:get, redirect_url4)
+              .to_return(status: 302, headers: { 'Location' => google_image_url })
+          end
+
+          it '404 Not Found を返す' do
+            get cover_proxy_books_path, params: { url: google_image_url }
+
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
`/books/cover_proxy` エンドポイントが `Net::HTTP` のデフォルト動作によりHTTPリダイレクト（302等）を追わないバグを修正する。

## 変更内容

### `app/controllers/books_controller.rb`
- `ALLOWED_REDIRECT_HOSTS` 定数を追加（`books.google.com`, `lh3.googleusercontent.com`）
- `MAX_REDIRECTS = 3` 定数を追加（無限ループ防止）
- `fetch_with_redirects` プライベートメソッドを追加（リダイレクト追跡ロジック）
- `cover_proxy` アクションを `fetch_with_redirects` を使う形に修正
- 許可外ドメインへのリダイレクトは `403 Forbidden` を返す

### `spec/requests/cover_proxy_spec.rb`
- 302リダイレクト追跡のテストケースを追加
  - Google系ドメインへのリダイレクトで正常取得できるケース
  - 許可外ドメインへのリダイレクトで403を返すケース
  - 最大リダイレクト数超過で404を返すケース

## テスト結果
- `bundle exec rspec spec/requests/cover_proxy_spec.rb`: 14 examples, 0 failures
- `bundle exec rspec`: 358 examples, 0 failures
- `bundle exec rubocop`: no offenses detected

Closes #158