### PR TITLE
#166 Google Books API キーを環境変数で設定する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,9 @@ DB_PASSWORD=
 # ---------------------------
 # RAILS_LOG_TO_STDOUT=true
 # RAILS_SERVE_STATIC_FILES=true
+
+# ---------------------------
+# 外部API
+# ---------------------------
+GOOGLE_BOOKS_API_KEY=your_google_books_api_key_here
+RAKUTEN_APPLICATION_ID=your_rakuten_application_id_here

--- a/.steering/20260506-issue166-google-books-api-key/design.md
+++ b/.steering/20260506-issue166-google-books-api-key/design.md
@@ -1,0 +1,43 @@
+# Design: Issue #166 Google Books API キー設定
+
+## 実装アプローチ
+
+### 1. `search_by_title` への key パラメータ追加
+
+`ENV["GOOGLE_BOOKS_API_KEY"].presence` で値を取得し、存在する場合のみ
+クエリパラメータに `key:` を追加する。
+存在しない場合は現状と同じキーなし呼び出しとなり、後退なし。
+
+```ruby
+def search_by_title(title)
+  uri = URI("https://www.googleapis.com/books/v1/volumes")
+  params = { q: "intitle:#{title}", langRestrict: "ja", maxResults: 5 }
+  api_key = ENV["GOOGLE_BOOKS_API_KEY"].presence
+  params[:key] = api_key if api_key
+  uri.query = URI.encode_www_form(params)
+  # ...
+end
+```
+
+### 2. `.env.example` への追記
+
+既存のコメント構造に合わせ「外部API」セクションを新設して追記する。
+
+### 3. `render.yaml` への追記
+
+`SENDGRID_API_KEY` の下に `sync: false` エントリを2件追加する。
+
+### 4. `.env`（ローカル実行用・gitignore済み）
+
+実際のキー値はファイルへの書き込みではなく、ユーザーが手動でセットする。
+本実装では `.env` への書き込みは行わない（セキュリティ上の理由）。
+
+## セキュリティ方針
+- 実際のキー値はコード・コミット・Issue本文に含めない
+- `.env.example` にはプレースホルダー（`your_google_books_api_key_here`）のみ記載
+- `render.yaml` の `sync: false` により値はダッシュボードでのみ管理
+
+## 影響範囲
+- `search_by_title` のみ変更（`search_by_isbn` は Google Books を使わないため不要）
+- テスト: 既存のスタブは URL に `key=` パラメータが追加されてもマッチするよう
+  WebMock の正規表現スタブ（`/www\.googleapis\.com\/books\/v1\/volumes/`）で対応済み

--- a/.steering/20260506-issue166-google-books-api-key/requirements.md
+++ b/.steering/20260506-issue166-google-books-api-key/requirements.md
@@ -1,0 +1,27 @@
+# Requirements: Issue #166 Google Books API キー設定
+
+## 概要
+タイトル検索時に発生する「検索リクエストが制限されています」エラーを、
+Google Books API キーの設定によって解消する。
+
+## 背景
+- APIキーなしで Google Books API を呼び出しているため、無認証クォータ（数十〜100クエリ/日/IP）に達すると HTTP 429 が返される
+- `fetch_title_json` が 429 を受け取り `GoogleBooksApiError` をフロントに伝えている
+- APIキーを付けることで 1,000 クエリ/日（無料枠）に拡大できる
+- ユーザーから楽天ブックス APIキーも提供されたため、合わせて設定対象に含める
+
+## 対象 Issue
+- #166: [Fix] Google Books API キーを設定してタイトル検索の429エラーを解消する
+
+## 変更対象ファイル
+- `app/controllers/books_controller.rb` — `search_by_title` に `key:` パラメータ追加
+- `.env.example` — `GOOGLE_BOOKS_API_KEY`, `RAKUTEN_APPLICATION_ID` のプレースホルダー追加
+- `render.yaml` — 両キーのエントリを `sync: false` で追加
+- `spec/requests/books_search_spec.rb` — APIキーありのケースをテスト追加（任意）
+
+## 受け入れ条件
+- [ ] `GOOGLE_BOOKS_API_KEY` 環境変数が設定されている状態でタイトル検索が正常に動作する
+- [ ] キーが未設定でも既存の動作（キーなし呼び出し）が維持される
+- [ ] `.env.example` に `GOOGLE_BOOKS_API_KEY`・`RAKUTEN_APPLICATION_ID` のプレースホルダーが追加されている
+- [ ] `render.yaml` に両キーのエントリが追加されている
+- [ ] RSpec / RuboCop が全通過する

--- a/.steering/20260506-issue166-google-books-api-key/tasklist.md
+++ b/.steering/20260506-issue166-google-books-api-key/tasklist.md
@@ -1,0 +1,24 @@
+# Tasklist: Issue #166 Google Books API キー設定
+
+## フェーズ1: コード変更
+
+- [x] `search_by_title` に `GOOGLE_BOOKS_API_KEY` の key パラメータを追加する
+- [x] `.env.example` に `GOOGLE_BOOKS_API_KEY` と `RAKUTEN_APPLICATION_ID` のプレースホルダーを追加する
+- [x] `render.yaml` に `GOOGLE_BOOKS_API_KEY` と `RAKUTEN_APPLICATION_ID` のエントリを追加する
+
+## フェーズ2: 検証
+
+- [x] `bundle exec rspec` を実行して全テストが通過することを確認する（358 examples, 0 failures）
+- [x] `bundle exec rubocop` を実行してエラーがないことを確認する
+
+## フェーズ3: コミット・PR
+
+- [ ] 変更をコミットする（メッセージ: `#166 Google Books API キーを環境変数で設定する`）
+- [ ] `feature/#166-google-books-api-key` をリモートにプッシュする
+- [ ] PR を作成して CI を確認する
+
+---
+
+## 振り返り（実装後に記載）
+
+<!-- 実装完了後に記入 -->

--- a/.steering/20260506-issue166-google-books-api-key/tasklist.md
+++ b/.steering/20260506-issue166-google-books-api-key/tasklist.md
@@ -25,8 +25,8 @@
 2026-05-06
 
 ### 計画と実績の差分
-- 計画どおり3ファイル（`books_controller.rb`, `.env.example`, `render.yaml`）のみ変更で完了
-- テスト追加は不要（既存の WebMock スタブが正規表現マッチのため `key=` パラメータ追加後も全通過）
+- Copilotレビュー指摘を反映し、`spec/requests/books_search_spec.rb` に `key=` パラメータ付与の検証テストを追加
+- `render.yaml` のインデント不備と `search_by_title` の変数名（`params`）を修正
 
 ### 学んだこと
 - `ENV["KEY"].presence` を使うことで、未設定時にパラメータを付けないシンプルな条件分岐が書ける

--- a/.steering/20260506-issue166-google-books-api-key/tasklist.md
+++ b/.steering/20260506-issue166-google-books-api-key/tasklist.md
@@ -13,12 +13,26 @@
 
 ## フェーズ3: コミット・PR
 
-- [ ] 変更をコミットする（メッセージ: `#166 Google Books API キーを環境変数で設定する`）
-- [ ] `feature/#166-google-books-api-key` をリモートにプッシュする
-- [ ] PR を作成して CI を確認する
+- [x] 変更をコミットする（メッセージ: `#166 Google Books API キーを環境変数で設定する`）
+- [x] `feature/#166-google-books-api-key` をリモートにプッシュする
+- [x] PR #167 を作成して CI を確認する（CI: success）
 
 ---
 
 ## 振り返り（実装後に記載）
 
-<!-- 実装完了後に記入 -->
+### 実装完了日
+2026-05-06
+
+### 計画と実績の差分
+- 計画どおり3ファイル（`books_controller.rb`, `.env.example`, `render.yaml`）のみ変更で完了
+- テスト追加は不要（既存の WebMock スタブが正規表現マッチのため `key=` パラメータ追加後も全通過）
+
+### 学んだこと
+- `ENV["KEY"].presence` を使うことで、未設定時にパラメータを付けないシンプルな条件分岐が書ける
+- `render.yaml` の `sync: false` はシークレット値をダッシュボードのみで管理するための慣習的な書き方
+- `RAKUTEN_APPLICATION_ID` は別 Issue で実装済みだが、環境変数定義の整備をこの Issue で合わせて行えた
+
+### 次回への改善提案
+- ローカル開発環境のセットアップ手順（`.env` へのキー設定方法）を `README.md` に明記するとよい
+- Render ダッシュボードでのキー設定手順も `docs/development-workflow.md` に追記することを推奨

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -175,7 +175,10 @@ class BooksController < ApplicationController
 
   def search_by_title(title)
     uri = URI("https://www.googleapis.com/books/v1/volumes")
-    uri.query = URI.encode_www_form(q: "intitle:#{title}", langRestrict: "ja", maxResults: 5)
+    params = { q: "intitle:#{title}", langRestrict: "ja", maxResults: 5 }
+    api_key = ENV["GOOGLE_BOOKS_API_KEY"].presence
+    params[:key] = api_key if api_key
+    uri.query = URI.encode_www_form(params)
     data = fetch_title_json(uri.to_s)
     items = data&.dig("items") || []
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -175,10 +175,10 @@ class BooksController < ApplicationController
 
   def search_by_title(title)
     uri = URI("https://www.googleapis.com/books/v1/volumes")
-    params = { q: "intitle:#{title}", langRestrict: "ja", maxResults: 5 }
+    query_params = { q: "intitle:#{title}", langRestrict: "ja", maxResults: 5 }
     api_key = ENV["GOOGLE_BOOKS_API_KEY"].presence
-    params[:key] = api_key if api_key
-    uri.query = URI.encode_www_form(params)
+    query_params[:key] = api_key if api_key
+    uri.query = URI.encode_www_form(query_params)
     data = fetch_title_json(uri.to_s)
     items = data&.dig("items") || []
 

--- a/render.yaml
+++ b/render.yaml
@@ -25,7 +25,7 @@ services:
         sync: false
       - key: SENDGRID_API_KEY
         sync: false
-        - key: GOOGLE_BOOKS_API_KEY
-          sync: false
-        - key: RAKUTEN_APPLICATION_ID
-          sync: false
+      - key: GOOGLE_BOOKS_API_KEY
+        sync: false
+      - key: RAKUTEN_APPLICATION_ID
+        sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -25,3 +25,7 @@ services:
         sync: false
       - key: SENDGRID_API_KEY
         sync: false
+        - key: GOOGLE_BOOKS_API_KEY
+          sync: false
+        - key: RAKUTEN_APPLICATION_ID
+          sync: false

--- a/spec/requests/books_search_spec.rb
+++ b/spec/requests/books_search_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe 'Books Search', type: :request do
           json = JSON.parse(response.body)
           expect(json['books'].length).to eq(2)
         end
+
+        it 'GOOGLE_BOOKS_API_KEY が設定されている場合は key パラメータ付きで Google Books を呼ぶ' do
+          stub_const('ENV', ENV.to_h.merge('GOOGLE_BOOKS_API_KEY' => 'test_google_api_key'))
+
+          get search_books_path, params: { q: 'リーダブルコード' }
+
+          expect(WebMock).to have_requested(:get, /www\.googleapis\.com\/books\/v1\/volumes/)
+            .with { |request| request.uri.query.to_s.include?('key=test_google_api_key') }
+        end
       end
 
       context 'Google Books APIが429を返した場合' do


### PR DESCRIPTION
## 概要
Google Books API キー（`GOOGLE_BOOKS_API_KEY`）と楽天ブックス API キー（`RAKUTEN_APPLICATION_ID`）を環境変数で管理する対応。
タイトル検索時の429エラー「検索リクエストが制限されています」を解消する。

## 変更内容

### `app/controllers/books_controller.rb`
- `search_by_title` にて `GOOGLE_BOOKS_API_KEY` 環境変数が設定されている場合のみ `key:` パラメータを付加するよう変更
- 未設定時は従来どおりキーなしで呼び出し（後退なし）

### `.env.example`
- `GOOGLE_BOOKS_API_KEY` と `RAKUTEN_APPLICATION_ID` のプレースホルダーを追加

### `render.yaml`
- `GOOGLE_BOOKS_API_KEY` と `RAKUTEN_APPLICATION_ID` を `sync: false` でエントリ追加
- 実際のキー値は Render ダッシュボードで設定する

## テスト結果
- RSpec: 358 examples, 0 failures
- RuboCop: no offenses detected

## 注意事項
- 実際の API キー値はコードに含めていません
- ローカル開発時は `.env` に設定してください（`.gitignore` 管理済み）
- 本番（Render）は ダッシュボードの Environment タブで設定してください

Closes #166