### PR TITLE
#190 Project AutomationのPR作成時実行を停止

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened]
   pull_request:
-    types: [opened, closed]
+    types: [closed]
 
 jobs:
   # ─────────────────────────────────────────

--- a/.steering/20260517-issue190-project-automation-pr-opened-stop/design.md
+++ b/.steering/20260517-issue190-project-automation-pr-opened-stop/design.md
@@ -1,0 +1,93 @@
+# 設計書: Project AutomationのPR作成時実行停止
+
+## アーキテクチャ概要
+
+GitHub Actions のイベントトリガー定義を最小限に調整する構成。
+
+```
+Issue opened/reopened -> add_to_project job 実行
+PR closed + merged==true -> move_to_done job 実行
+PR opened -> 何も実行しない
+```
+
+## コンポーネント設計
+
+### 1. `.github/workflows/project-automation.yml`
+
+**責務**:
+- Project Automation のイベントトリガーを定義する。
+- PR マージ時に linked issue を Done へ移動する。
+
+**実装の要点**:
+- `on.pull_request.types` を `closed` のみにする。
+- `move_to_done` ジョブの `if` 条件 (`closed` + `merged == true`) は現状維持する。
+
+### 2. 運用ドキュメント
+
+**責務**:
+- 開発者に「いつ workflow が動くか」を伝える。
+
+**実装の要点**:
+- PR 作成時には実行しない点を明記する。
+- Issue の opened/reopened と PR merged 時の実行を明記する。
+
+## データフロー
+
+### Project Automation 実行判定
+```
+1. GitHub event を受信
+2. event_name/action で workflow のトリガー判定
+3. jobs.if 条件で実行可否を最終判定
+4. add_to_project または move_to_done を実行
+```
+
+## エラーハンドリング戦略
+
+### 設定ミス防止
+- YAML 構文が壊れていないことをチェックする。
+- `move_to_done` の条件式を維持し、想定外イベント起動を抑制する。
+
+## テスト戦略
+
+### 静的確認
+- workflow YAML を読み、`pull_request.types` から `opened` が除外されていることを確認。
+- `issues.types` が `opened, reopened` のまま維持されていることを確認。
+- `move_to_done` の `if` 条件が `closed` + `merged == true` を維持していることを確認。
+
+### 実行系確認
+- `bundle exec rspec`
+- `bundle exec rubocop`
+
+## 依存ライブラリ
+
+追加なし。
+
+## ディレクトリ構造
+
+```
+.github/workflows/project-automation.yml   # 変更
+docs/development-workflow.md               # 変更（運用記述）
+.steering/20260517-issue190-project-automation-pr-opened-stop/
+	requirements.md                          # 新規
+	design.md                                # 新規
+	tasklist.md                              # 新規
+```
+
+## 実装の順序
+
+1. workflow トリガーを修正
+2. 運用ドキュメントを更新
+3. テスト/リントで回帰確認
+4. ステアリングの振り返りを記載
+
+## セキュリティ考慮事項
+
+- Token や Project ID など secret 参照部分は変更しない。
+
+## パフォーマンス考慮事項
+
+- 不要な workflow 起動を減らし、Actions ノイズと実行時間を削減する。
+
+## 将来の拡張性
+
+- 将来的に PR `reopened` 時だけ実行したい場合は、`pull_request.types` に個別追加できる設計を維持する。

--- a/.steering/20260517-issue190-project-automation-pr-opened-stop/requirements.md
+++ b/.steering/20260517-issue190-project-automation-pr-opened-stop/requirements.md
@@ -1,0 +1,49 @@
+# 要求内容: Project AutomationのPR作成時実行停止
+
+## 概要
+
+Issue #190 に対応し、Project Automation ワークフローが PR 作成時に実行されないようにトリガーを見直す。
+PR マージ時の linked issue を Done へ移動する挙動と、Issue 作成/再オープン時の自動追加は維持する。
+
+## 背景
+
+現在の `.github/workflows/project-automation.yml` は `pull_request` の `opened` をトリガーに含んでいるため、PR 作成直後に不要なジョブが走り Actions 一覧のノイズになっている。
+
+## 実装対象の機能
+
+### 1. Workflowトリガーの最小化
+- `project-automation.yml` の `pull_request.types` から `opened` を除外する。
+- PR マージ時に必要な `closed` イベントによる処理は維持する。
+- Issue の `opened/reopened` による自動追加は維持する。
+
+### 2. 運用ドキュメント更新
+- 変更後に Project Automation がいつ実行されるかを README または運用メモへ明記する。
+
+## 受け入れ条件
+
+### Workflowトリガー
+- [ ] PR 作成時に Project Automation が起動しない。
+- [ ] PR マージ時に linked issue を Done に移動する条件が維持される。
+- [ ] Issue 作成/再オープン時の自動追加が維持される。
+
+### ドキュメント
+- [ ] 実行タイミング変更が README または運用ドキュメントに明記されている。
+
+## 成功指標
+
+- Actions 一覧で PR 作成時の Project Automation 実行が発生しない。
+- 既存の PR マージ時/Issue 作成時の運用が回帰しない。
+
+## スコープ外
+
+以下はこのフェーズでは実装しない:
+
+- Project board のステータス値やフィールドIDの見直し
+- CI 全体構成の刷新
+- 他 workflow のトリガー最適化
+
+## 参照ドキュメント
+
+- `docs/development-workflow.md` - 運用フロー
+- `docs/development-guidelines.md` - 開発ガイドライン
+- `issue/ISSUE.md` - Issue 一覧

--- a/.steering/20260517-issue190-project-automation-pr-opened-stop/tasklist.md
+++ b/.steering/20260517-issue190-project-automation-pr-opened-stop/tasklist.md
@@ -1,0 +1,58 @@
+# タスクリスト: Project AutomationのPR作成時実行停止
+
+## 🚨 タスク完全完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+---
+
+## フェーズ1: Workflow修正
+
+- [x] `.github/workflows/project-automation.yml` の `pull_request.types` から `opened` を除外
+	- [x] `issues.types` が `opened, reopened` のまま維持されていることを確認
+	- [x] `move_to_done` 条件 (`closed` + `merged == true`) が維持されていることを確認
+
+## フェーズ2: ドキュメント更新
+
+- [x] 運用ドキュメントに実行タイミングを明記
+	- [x] PR作成時に実行されないことを記載
+	- [x] Issue opened/reopened と PR merged 時に実行されることを記載
+
+## フェーズ3: 検証
+
+- [x] `bundle exec rspec` が通ることを確認
+- [x] `bundle exec rubocop` が通ることを確認
+- [x] ワークフロー設定の静的確認（trigger条件）
+
+## フェーズ4: 振り返り
+
+- [x] 実装後の振り返りを記載
+
+---
+
+## 実装後の振り返り
+
+### 実装完了日
+2026-05-17
+
+### 計画と実績の差分
+
+**計画と異なった点**:
+- `README.md` ではなく運用ドキュメント `docs/development-workflow.md` を更新対象とした（Issue 要件の「READMEまたは運用メモ」を満たすため）。
+- プロンプトの `npm test/lint/typecheck` は Rails リポジトリ（`package.json` 不在）では実行できないため、プロジェクト標準の `bundle exec rspec` / `bundle exec rubocop` を検証コマンドとして採用した。
+
+**新たに必要になったタスク**:
+- 変更後の trigger 条件を `grep` で静的確認し、`issues` と `pull_request` の対象イベントが要件どおりであることを証跡化した。
+
+### 学んだこと
+
+**技術的な学び**:
+- Project Automation のノイズ削減は `on.pull_request.types` の最小化だけで実現でき、ジョブ側の `if` 条件を変更せずに安全に達成できる。
+- `pull_request.closed` はマージ済み/クローズのみの共通イベントであり、`merged == true` 条件を維持することでマージ時処理だけを確実に残せる。
+
+**プロセス上の改善点**:
+- ステアリングのチェックボックスを実装と同時に更新することで、implementation-validator 指摘前に完了証跡を揃えるべきだった。
+
+### 次回への改善提案
+- 実装着手前に「このリポジトリで有効な検証コマンド（Ruby系/Node系）」を先に確認し、プロンプトとの差分を早期に tasklist に反映する。
+- workflow 変更時はドキュメント例の YAML 断片も同時に更新し、運用手順との不整合を防止する。

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -346,7 +346,7 @@ services:
 
 ## ステップ 4: GitHub Project の自動化
 
-### PR 作成 → "In Review" へ自動移動
+### Issue 作成/再オープン時の自動追加 + PRマージ時のDone移動
 
 ```yaml
 # .github/workflows/project-automation.yml
@@ -354,18 +354,14 @@ services:
 name: Project Automation
 
 on:
+  issues:
+    types: [opened, reopened]
   pull_request:
-    types: [opened, reopened, closed]
-
-permissions:
-  contents: read
-  pull-requests: read
+    types: [closed]
 
 jobs:
-  # PR 作成時 → プロジェクトに追加（ステータスの "In Review" 移動は手動で行う）
-  # 注意: actions/add-to-project はプロジェクトへの追加のみ行い、カードのステータス変更は行いません。
-  # PR作成後は Projects ボード上で手動に "In Review" へ移動してください。
-  move-to-review:
+  # Issue 作成時/再オープン時 → プロジェクトに追加
+  add-to-project:
     if: github.event.action == 'opened' || github.event.action == 'reopened'
     runs-on: ubuntu-latest
     steps:
@@ -374,9 +370,20 @@ jobs:
           project-url: https://github.com/users/liverpl1920/projects/2
           github-token: ${{ secrets.PROJECT_TOKEN }}
 
-  # PR マージ → Issue 自動クローズ（PR 本文に "Closes #番号" を書く）
-  # GitHub がデフォルトで対応（branch protection 設定で有効化）
+  # PR close かつ merge=true のときに linked issue を Done に移動
+  move-to-done:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
 ```
+
+運用ルール:
+
+- PR 作成時（opened）には Project Automation は実行されません。
+- Issue の opened/reopened ではプロジェクトへ自動追加されます。
+- PR が merged されたときのみ linked issue の Done 移動処理が実行されます。
 
 ### PR テンプレートの設定
 


### PR DESCRIPTION
## 概要
Issue #190 に対応し、Project Automation が PR 作成時（opened）に実行されないよう trigger を修正しました。

## 変更内容
- `.github/workflows/project-automation.yml` の `pull_request.types` を `[closed]` に変更（`opened` を除外）
- Issue `opened/reopened` の自動追加処理は維持
- PR merge 時の linked issue Done 移動条件（`closed` + `merged == true`）は維持
- `docs/development-workflow.md` に実行タイミングの新ルールを明記
- `.steering/20260517-issue190-project-automation-pr-opened-stop/` を追加

## テスト結果
- `bundle exec rspec` : pass（395 examples, 0 failures）
- `bundle exec rubocop` : pass（86 files, no offenses）
- trigger 条件の静的確認 : pass
- `npm test/lint/typecheck` : package.json 未存在のため非適用（Rails構成）

Closes #190