### PR TITLE
#226 #227 積読・過去読書登録時の読了期限を任意化

### DIFF
--- a/.steering/20260524-deadline-optional-226-227/design.md
+++ b/.steering/20260524-deadline-optional-226-227/design.md
@@ -1,0 +1,88 @@
+# 設計: ISSUE#226, #227 読了期限の任意化
+
+## 実装方針
+
+### モデル設計
+
+#### deadline バリデーション条件の変更
+
+```ruby
+# 変更前
+validates :deadline, presence: true
+
+# 変更後
+validates :deadline, presence: true, unless: :deadline_optional?
+```
+
+#### deadline_optional? メソッド
+
+```ruby
+def deadline_optional?
+  past_reading_checked? ||
+    (unread? && !will_transition_to_reading?) ||
+    completed?
+end
+```
+
+- `past_reading_checked?`: is_past_reading フラグ（Issue#226）
+- `unread? && !will_transition_to_reading?`: 積読状態かつ unread→reading 遷移しない（Issue#227）
+- `completed?`: 読了済み書籍の編集時に nil deadline を許容（過去読書書籍の再編集）
+
+#### will_transition_to_reading? メソッド
+
+```ruby
+def will_transition_to_reading?
+  unread? && persisted? &&
+    current_page_changed? &&
+    current_page_was.to_i.zero? &&
+    current_page.to_i > 0
+end
+```
+
+auto_set_reading_status コールバックと同じ条件を検証時にチェック。
+
+#### nil 安全化が必要なメソッド
+
+| メソッド | 変更内容 |
+|---------|---------|
+| `days_remaining` | `return nil if deadline.nil?` を追加 |
+| `overdue?` | `return false if deadline.nil?` を追加 |
+| `deadline_urgency_class` | `return "" if completed? \|\| deadline.nil?` に変更 |
+| `daily_quota` | `return 0 if completed? \|\| deadline.nil?` に変更 |
+| `extend_deadline!` | `deadline.nil?` 時の比較保護を追加 |
+
+### ビュー設計
+
+#### _form.html.erb
+
+- deadline ラベルを条件分岐: 新規 or unread or completed → 「任意」、reading → 「必須」
+
+```erb
+<% deadline_optional_for_form = book.new_record? || book.unread? || book.completed? %>
+```
+
+#### show.html.erb
+
+1. **読了期限表示セクション**: nil の場合は「未設定」を表示
+2. **進捗更新フォーム**: unread && deadline.nil? の場合は非表示にし、設定案内を表示
+3. **読了ボタン**: unread && deadline.nil? の場合は非表示
+4. **期限延長ボタン/モーダル**: deadline.nil? の場合は非表示
+5. **今日のノルマ表示**: deadline.nil? の場合は「-」を表示
+
+#### index.html.erb
+
+- `l(book.deadline, format: :long)` の nil ガード: nil の場合は「未設定」を表示
+
+### スペック設計
+
+#### 更新が必要なテスト
+
+- `'読了期限がない場合は無効'` → `unread` ステータスでは nil でも有効に変更
+
+#### 追加するテスト
+
+- 積読書籍は読了期限なしで有効
+- 積読書籍の読書中遷移（initial progress）では読了期限が必須
+- 過去読書（is_past_reading）では読了期限なしで有効
+- 読書中書籍は読了期限なしで無効
+- 読了済み書籍は読了期限なしで有効（編集ケース対応）

--- a/.steering/20260524-deadline-optional-226-227/requirements.md
+++ b/.steering/20260524-deadline-optional-226-227/requirements.md
@@ -1,0 +1,47 @@
+# 要件定義: ISSUE#226, #227 読了期限の任意化
+
+## 作業概要
+
+- **Issue #226**: 過去に読んだ本の登録時は読了期限を必須にしない
+- **Issue #227**: 積読登録時は読了期限を必須にせず、読み始めた時点で必須にする
+
+## 背景
+
+現在 `validates :deadline, presence: true` により全書籍で読了期限が必須。
+- 積読（unread）登録時にまだ期限が決まっていないケースに対応できない
+- 過去読書登録時に当時の期限を正確に入力できないケースに対応できない
+
+## 要件詳細
+
+### ISSUE#226: 過去読書登録時の期限任意化
+
+- `is_past_reading` フラグが true の場合、読了期限を任意入力とする
+- 読了期限が未入力でも保存できる
+- 完了条件: 過去読書登録時に読了期限未入力で保存できる
+
+### ISSUE#227: 積読登録時の期限任意化
+
+- 積読（unread ステータス）で登録する場合、読了期限を任意入力とする
+- 読み始めた（unread → reading への遷移）タイミングでは読了期限が必須
+- `auto_set_reading_status` が発動するタイミング（current_page が 0 → >0）で必須チェック
+- 完了条件:
+  1. 積読登録時に読了期限未入力で保存できる
+  2. 読書開始時（進捗更新で unread → reading 遷移）は読了期限が必須
+  3. 既存の登録・編集・状態変更機能に回帰不具合がない
+
+## 現行仕様の「読み始めたタイミング」定義
+
+`auto_set_reading_status` コールバックの発動条件：
+- `unread?` であること
+- `persisted?` であること（既存レコード）
+- `current_page` が変化すること
+- `current_page_was` が 0 であること（初めての進捗記録）
+- 新しい `current_page` が 0 より大きいこと
+
+## 影響範囲
+
+- `app/models/book.rb` - バリデーションロジック
+- `app/views/books/_form.html.erb` - フォームのUI（必須/任意ラベル）
+- `app/views/books/show.html.erb` - 詳細画面（nil deadline 対応）
+- `app/views/books/index.html.erb` - 一覧画面（nil deadline 対応）
+- `spec/models/book_spec.rb` - モデルスペック更新・追加

--- a/.steering/20260524-deadline-optional-226-227/tasklist.md
+++ b/.steering/20260524-deadline-optional-226-227/tasklist.md
@@ -1,0 +1,51 @@
+# タスクリスト: ISSUE#226, #227 読了期限の任意化
+
+## フェーズ1: モデル変更
+
+- [x] T1: `validates :deadline, presence: true` に `unless: :deadline_optional?` を追加
+- [x] T2: `deadline_optional?` プライベートメソッドを追加
+- [x] T3: `will_transition_to_reading?` プライベートメソッドを追加
+- [x] T4: `days_remaining` を nil 安全化
+- [x] T5: `overdue?` を nil 安全化
+- [x] T6: `deadline_urgency_class` を nil 安全化
+- [x] T7: `daily_quota` を nil 安全化
+- [x] T8: `extend_deadline!` を nil 安全化
+
+## フェーズ2: ビュー変更
+
+- [x] T9: `_form.html.erb` の deadline ラベルを条件分岐（必須/任意）に変更
+- [x] T10: `show.html.erb` の読了期限表示セクションを nil 対応
+- [x] T11: `show.html.erb` の進捗更新フォームを unread+deadline nil 時に非表示
+- [x] T12: `show.html.erb` の読了ボタンを unread+deadline nil 時に非表示
+- [x] T13: `show.html.erb` の期限延長ボタン/モーダルを deadline nil 時に非表示
+- [x] T14: `show.html.erb` の今日のノルマ表示を deadline nil 時に「-」表示
+- [x] T15: `index.html.erb` の deadline 表示を nil 対応
+
+## フェーズ3: スペック更新・追加
+
+- [x] T16: `'読了期限がない場合は無効'` テストを unread 限定に変更
+- [x] T17: 積読書籍での deadline nil 有効テストを追加
+- [x] T18: 積読→読書中遷移時の deadline 必須テストを追加
+- [x] T19: 過去読書での deadline nil 有効テストを追加
+- [x] T20: 読書中書籍での deadline nil 無効テストを追加
+- [x] T21: 読了済み書籍での deadline nil 有効テストを追加（編集ケース）
+
+---
+
+## 振り返り
+
+**実装完了日**: 2026-05-24
+
+**計画と実績の差分**:
+- 計画通り21タスクを全て完了
+- DBのNOT NULL制約を解除するマイグレーション（T-DBとして追加）が計画外で必要だった
+  - `deadline` カラムにDB側のNOT NULL制約が残っていたため `create(:book, deadline: nil)` がActiveRecord::NotNullViolationを発生させた
+  - `ChangeDeadlineNullableInBooks` マイグレーションを追加して対応
+
+**学んだこと**:
+- Railsのモデルバリデーションを緩めても、DBスキーマのNOT NULL制約は独立して存在するため、両方の変更が必要
+- `will_transition_to_reading?` はバリデーション時点（before_save前）のオブジェクト状態を使うため、`auto_set_reading_status` コールバックと同じ条件を複製して検証できる
+
+**次回への改善提案**:
+- スキーマ変更を伴うバリデーション緩和では、マイグレーションの必要性を設計段階で洗い出しておく
+- `deadline_optional?` の完了済みケース（`completed?`）は、将来的にビジネス要件が変わった場合に見直しが必要

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -19,7 +19,7 @@ class Book < ApplicationRecord
   validates :total_pages, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :target_pages, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :current_page, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-  validates :deadline, presence: true
+  validates :deadline, presence: true, unless: :deadline_optional?
   validates :status, presence: true
 
   validate :target_pages_not_exceed_total_pages
@@ -35,7 +35,7 @@ class Book < ApplicationRecord
 
   def extend_deadline!(new_deadline)
     return false if new_deadline.blank?
-    return errors.add(:deadline, :must_be_after_current_deadline) && false if new_deadline <= deadline
+    return errors.add(:deadline, :must_be_after_current_deadline) && false if deadline.present? && new_deadline <= deadline
 
     self.deadline = new_deadline
     self.extension_count += 1
@@ -73,7 +73,7 @@ class Book < ApplicationRecord
   # 今日のノルマ（残ページ ÷ 残日数、切り上げ）
   # 期限超過時（D <= 0）は D=1 として計算する
   def daily_quota
-    return 0 if completed?
+    return 0 if completed? || deadline.nil?
 
     remaining = target_pages - current_page
     return 0 if remaining <= 0
@@ -92,17 +92,21 @@ class Book < ApplicationRecord
 
   # 残り日数（今日を含む／期限当日は D=1）
   def days_remaining
+    return nil if deadline.nil?
+
     (deadline - Date.current).to_i + 1
   end
 
   # 期限超過判定（D <= 0、すなわち期限日翌日以降）
   def overdue?
+    return false if deadline.nil?
+
     days_remaining <= 0
   end
 
   # 賞味期限ビジュアライザー用CSSクラス
   def deadline_urgency_class
-    return "" if completed?
+    return "" if completed? || deadline.nil?
 
     days = days_remaining
     if days <= 1
@@ -173,6 +177,19 @@ class Book < ApplicationRecord
     return if current_page.blank? || total_pages.blank?
 
     errors.add(:current_page, :less_than_or_equal_to_total_pages, count: total_pages) if current_page > total_pages
+  end
+
+  def deadline_optional?
+    past_reading_checked? ||
+      (unread? && !will_transition_to_reading?) ||
+      completed?
+  end
+
+  def will_transition_to_reading?
+    unread? && persisted? &&
+      current_page_changed? &&
+      current_page_was.to_i.zero? &&
+      current_page.to_i > 0
   end
 
   def deadline_cannot_be_in_the_past

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -37,8 +37,8 @@ class Book < ApplicationRecord
     return false if new_deadline.blank?
     return errors.add(:deadline, :must_be_after_current_deadline) && false if deadline.present? && new_deadline <= deadline
 
+    self.extension_count += 1 if deadline.present?
     self.deadline = new_deadline
-    self.extension_count += 1
     save
   end
 

--- a/app/views/books/_form.html.erb
+++ b/app/views/books/_form.html.erb
@@ -103,9 +103,14 @@
   </div>
 
   <%# 読了期限 %>
+  <% deadline_optional_for_form = book.new_record? || book.unread? || book.completed? %>
   <div class="form-field">
     <%= f.label :deadline, '読了期限', class: 'form-field__label' %>
-    <span class="form-field__required" aria-hidden="true">必須</span>
+    <% if deadline_optional_for_form %>
+      <span class="form-field__optional">任意</span>
+    <% else %>
+      <span class="form-field__required" aria-hidden="true">必須</span>
+    <% end %>
     <%= f.date_field :deadline,
           class: "form-field__input form-field__input--date #{'form-field__input--error' if book.errors[:deadline].any?}",
           min: (book.completed? ? nil : Date.current.to_s),

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -140,7 +140,13 @@
                 <%# 読了期限 %>
                 <div class="book-card__deadline">
                   <span class="book-card__deadline-label">読了期限</span>
-                  <span class="book-card__deadline-value"><%= l(book.deadline, format: :long) %></span>
+                  <span class="book-card__deadline-value">
+                    <% if book.deadline.present? %>
+                      <%= l(book.deadline, format: :long) %>
+                    <% else %>
+                      未設定
+                    <% end %>
+                  </span>
                 </div>
 
                 <%# 進捗バー %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -52,7 +52,14 @@
     </div>
 
     <% remaining_pages = @book.target_pages - @book.current_page %>
-    <% if !@book.completed? && remaining_pages > 0 %>
+    <%# 積読かつ読了期限未設定の場合は案内を表示 %>
+    <% if @book.unread? && @book.deadline.nil? %>
+      <div class="book-show__deadline-notice" role="alert">
+        <p>読み始めるには読了期限を設定してください。</p>
+        <%= link_to '書籍情報を編集する', edit_book_path(@book), class: 'btn btn--secondary btn--sm' %>
+      </div>
+    <% end %>
+    <% if !@book.completed? && remaining_pages > 0 && !(@book.unread? && @book.deadline.nil?) %>
       <%# 進捗更新フォーム %>
       <div class="book-show__progress-update"
            data-controller="progress-update"
@@ -132,7 +139,7 @@
     <% end %>
 
     <%# 読了ボタン (W-6) %>
-    <% unless @book.completed? %>
+    <% unless @book.completed? || (@book.unread? && @book.deadline.nil?) %>
       <% complete_btn_class = @book.progress_percentage >= 100 ? 'book-show__complete-btn book-show__complete-btn--highlighted' : 'book-show__complete-btn' %>
       <div class="book-show__complete-section">
         <%= button_to '読了にする！', complete_book_path(@book),
@@ -155,9 +162,13 @@
       <div class="book-show__detail-item">
         <dt class="book-show__detail-label">読了期限</dt>
         <dd class="book-show__detail-value">
-          <time datetime="<%= @book.deadline %>">
-            <%= l(@book.deadline, format: :long) %>
-          </time>
+          <% if @book.deadline.present? %>
+            <time datetime="<%= @book.deadline %>">
+              <%= l(@book.deadline, format: :long) %>
+            </time>
+          <% else %>
+            <span class="book-show__detail-none">未設定</span>
+          <% end %>
         </dd>
       </div>
 
@@ -190,6 +201,8 @@
         <dd class="book-show__detail-value">
           <% if @book.completed? %>
             <span class="book-show__quota-done">読了済み</span>
+          <% elsif @book.deadline.nil? %>
+            <span class="book-show__detail-none">-</span>
           <% elsif @book.overdue? %>
             <span class="book-show__quota-overdue">期限超過</span>
           <% else %>
@@ -310,7 +323,7 @@
     <div class="book-show__actions">
       <%= link_to '一覧に戻る', books_path, class: 'btn btn--outline' %>
       <%= link_to '書籍情報を編集する', edit_book_path(@book), class: 'btn btn--secondary' %>
-      <% unless @book.completed? %>
+      <% unless @book.completed? || @book.deadline.nil? %>
         <button type="button" class="btn btn--secondary"
                 data-action="click->modal#openExtend">
           期限を延長する
@@ -390,6 +403,7 @@
   </div>
 
   <%# 期限延長モーダル (W-10) %>
+  <% if @book.deadline.present? %>
   <div class="modal-overlay"
        hidden
        aria-hidden="true"
@@ -436,6 +450,7 @@
       <% end %>
     </div>
   </div>
+  <% end %>
 
   <%# 読了お祝いモーダル (W-13) %>
   <% if flash[:completed_book].present? %>

--- a/db/migrate/20260523231135_change_deadline_nullable_in_books.rb
+++ b/db/migrate/20260523231135_change_deadline_nullable_in_books.rb
@@ -1,0 +1,5 @@
+class ChangeDeadlineNullableInBooks < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :books, :deadline, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_23_222517) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_23_231135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_23_222517) do
     t.integer "total_pages", null: false
     t.integer "target_pages", null: false
     t.integer "current_page", default: 0, null: false
-    t.date "deadline", null: false
+    t.date "deadline"
     t.integer "status", default: 0, null: false
     t.integer "extension_count", default: 0, null: false
     t.datetime "completed_at"

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -97,8 +97,38 @@ RSpec.describe Book, type: :model do
     end
 
     describe 'deadline' do
-      it '読了期限がない場合は無効' do
-        expect(build(:book, deadline: nil)).not_to be_valid
+      it '積読書籍（unread）は読了期限なしで有効' do
+        expect(build(:book, deadline: nil, status: :unread)).to be_valid
+      end
+
+      it '読書中書籍（reading）は読了期限なしで無効' do
+        book = build(:book, deadline: nil, status: :reading)
+        expect(book).not_to be_valid
+        expect(book.errors[:deadline]).not_to be_empty
+      end
+
+      it '読了済み書籍（completed）は読了期限なしで有効' do
+        book = build(:book, deadline: nil, status: :completed)
+        expect(book).to be_valid
+      end
+
+      it '過去読書（is_past_reading: true）は読了期限なしで有効' do
+        book = build(:book, deadline: nil)
+        book.is_past_reading = 'true'
+        expect(book).to be_valid
+      end
+
+      it '積読書籍が初回進捗記録で読書中へ遷移する際は読了期限が必須' do
+        book = create(:book, deadline: nil, status: :unread, current_page: 0)
+        book.current_page = 1
+        expect(book).not_to be_valid
+        expect(book.errors[:deadline]).not_to be_empty
+      end
+
+      it '積読書籍が初回進捗記録で遷移する際、期限があれば有効' do
+        book = create(:book, deadline: Date.current + 7, status: :unread, current_page: 0)
+        book.current_page = 1
+        expect(book).to be_valid
       end
 
       it '今日の日付であれば有効（新規作成時）' do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -588,6 +588,24 @@ RSpec.describe Book, type: :model do
   describe '#extend_deadline!' do
     let(:book) { create(:book, deadline: Date.current + 7, extension_count: 0) }
 
+    context '期限が未設定（nil）の状態で日付を渡した場合' do
+      let(:book_without_deadline) { create(:book, deadline: nil, status: :unread, extension_count: 0) }
+
+      it 'deadlineが設定される' do
+        book_without_deadline.extend_deadline!(Date.current + 14)
+        expect(book_without_deadline.reload.deadline).to eq(Date.current + 14)
+      end
+
+      it 'extension_countはインクリメントされない（初回設定のため）' do
+        book_without_deadline.extend_deadline!(Date.current + 14)
+        expect(book_without_deadline.reload.extension_count).to eq(0)
+      end
+
+      it 'trueを返す' do
+        expect(book_without_deadline.extend_deadline!(Date.current + 14)).to be_truthy
+      end
+    end
+
     context '現在の期限より後の日付を渡した場合' do
       it 'deadlineが更新される' do
         new_deadline = Date.current + 14


### PR DESCRIPTION
## 概要

ISSUE#226 と #227 を同時実装。
- 積読（unread）として本を登録する際、読了期限を必須にしない
- 過去に読んだ本として登録する際（is_past_reading: true）、読了期限を必須にしない
- 読み始めたタイミング（unread → reading 遷移）では読了期限が必須になる

## 変更内容

### `app/models/book.rb`
- `validates :deadline, presence: true` に `unless: :deadline_optional?` を追加
- `deadline_optional?`: past_reading_checked? || (unread? && !will_transition_to_reading?) || completed?
- `will_transition_to_reading?`: 初回進捗記録時の unread→reading 遷移判定
- `days_remaining`, `overdue?`, `deadline_urgency_class`, `daily_quota`, `extend_deadline!` を nil 安全化

### `app/views/books/_form.html.erb`
- deadline フィールドのラベルを条件分岐（新規・積読・読了済みは「任意」、読書中は「必須」）

### `app/views/books/show.html.erb`
- deadline nil 時の各セクション対応（表示、進捗フォーム、完了ボタン、期限延長モーダル、ノルマ表示）

### `app/views/books/index.html.erb`
- deadline nil 時に「未設定」を表示

### `db/migrate/20260523231135_change_deadline_nullable_in_books.rb`
- `deadline` カラムの NOT NULL 制約を削除

### `spec/models/book_spec.rb`
- deadline バリデーションテストを更新・追加（新規6ケース）

## テスト結果

- RSpec: 427 examples, 0 failures
- RuboCop: 91 files inspected, no offenses detected

Closes #226
Closes #227