### PR TITLE
#270 本番環境のActive Storage保存先をBackblaze B2へ切り替える

### DIFF
--- a/.steering/20260531-issue-270-backblaze-b2-storage/design.md
+++ b/.steering/20260531-issue-270-backblaze-b2-storage/design.md
@@ -1,0 +1,134 @@
+# 設計書
+
+## アーキテクチャ概要
+
+本対応は「B2 用ストレージ定義 + 起動時バリデーション + デプロイ設定更新 + 回帰テスト」の4層で実装する。
+
+```mermaid
+flowchart TD
+  A[production boot] --> B[Backblaze B2 config validator]
+  B -->|required env present| C[config.active_storage.service = :backblaze]
+  B -->|missing env| D[raise KeyError and abort boot]
+  C --> E[Active Storage S3-compatible service]
+  E --> F[Backblaze B2]
+
+  G[Render env vars] --> H[B2 specific keys]
+  I[tests] --> J[validator spec]
+  I --> K[production config spec]
+  I --> L[storage.yml spec]
+```
+
+## コンポーネント設計
+
+### 1. Backblaze B2 config validator
+
+**責務**:
+- production に必要な B2 環境変数の不足を判定する。
+- 不足時に例外を発生させ、誤設定のまま起動しないようにする。
+
+**実装の要点**:
+- 必須キーを定数化し、テストから確認できるようにする。
+- 値そのものはログに出さず、キー名のみをエラーに含める。
+
+### 2. production 設定と storage.yml
+
+**責務**:
+- production で Backblaze B2 を唯一の保存先として使う。
+- Active Storage のサービス定義を B2 の endpoint と path-style に合わせる。
+
+**実装の要点**:
+- production では validator を呼び出してから B2 サービスを有効化する。
+- `config/storage.yml` に B2 用の service 定義を追加し、endpoint と `force_path_style` を設定する。
+- AWS 前提のキー名を B2 用に差し替える。
+
+### 3. デプロイ設定とドキュメント
+
+**責務**:
+- Render の環境変数一覧を B2 用に揃える。
+- 運用者が必要な設定値を迷わず設定できるようにする。
+
+**実装の要点**:
+- `render.yaml` と `README.md`、関連ドキュメントの環境変数表記を一致させる。
+- S3 互換であることは明記しつつ、実運用は Backblaze B2 を指すようにする。
+
+## データフロー
+
+### production 起動時
+```
+1. production 初期化で B2 validator を呼ぶ
+2. 必須環境変数が足りなければ KeyError を raise して起動失敗する
+3. 問題なければ Backblaze B2 service を Active Storage に設定する
+```
+
+### デプロイ設定反映時
+```
+1. Render の環境変数を B2 用に設定する
+2. production 起動時の validator がその値を検証する
+3. Active Storage が Backblaze B2 に接続する
+```
+
+## エラーハンドリング戦略
+
+### カスタムエラークラス
+
+新規の例外クラスは作成しない。起動失敗は `KeyError` で表現する。
+
+### エラーハンドリングパターン
+
+- 必須キーが不足している場合は、キー名だけを含むエラーメッセージで fail-fast する。
+- B2 設定に関する値は秘匿し、ログや例外に環境変数値を出さない。
+
+## テスト戦略
+
+### ユニットテスト
+- B2 validator が不足キーを正しく返す。
+- B2 validator が不足時に `KeyError` を raise する。
+
+### 統合テスト
+- production 設定が Backblaze B2 validator と `:backblaze` サービスを参照する。
+- `config/storage.yml` の B2 定義が必要な endpoint 付きで存在する。
+
+## 依存ライブラリ
+
+新規追加なし。
+
+## ディレクトリ構造
+
+```
+app/
+  services/
+    active_storage_backblaze_b2_config_validator.rb   # 追加または更新
+config/
+  environments/
+    production.rb                                     # 更新
+  storage.yml                                         # 更新
+render.yaml                                           # 更新
+spec/
+  services/
+    active_storage_backblaze_b2_config_validator_spec.rb # 更新または追加
+  config/
+    production_active_storage_config_spec.rb           # 更新
+    storage_config_spec.rb                             # 追加
+```
+
+## 実装の順序
+
+1. B2 validator と production 設定を更新する
+2. `config/storage.yml` と `render.yaml` を B2 用に更新する
+3. 回帰テストを追加する
+4. RSpec / RuboCop で検証する
+
+## セキュリティ考慮事項
+
+- エラーやログに秘密情報を含めない。
+- B2 endpoint は設定値として扱い、ハードコードを最小限にする。
+
+## パフォーマンス考慮事項
+
+- 起動時検証は 1 回だけ行う。
+- Active Storage の利用パスは production 起動後に追加オーバーヘッドを増やさない。
+
+## 将来の拡張性
+
+- B2 以外の S3 互換サービスへ切り替える場合も、validator と `storage.yml` を差し替えやすい構造にする。
+- 必須環境変数の追加があっても定数と spec を更新するだけで追従できる。

--- a/.steering/20260531-issue-270-backblaze-b2-storage/design.md
+++ b/.steering/20260531-issue-270-backblaze-b2-storage/design.md
@@ -97,7 +97,7 @@ flowchart TD
 ```
 app/
   services/
-    active_storage_backblaze_b2_config_validator.rb   # 追加または更新
+    active_storage_s3_config_validator.rb             # 更新
 config/
   environments/
     production.rb                                     # 更新
@@ -105,7 +105,7 @@ config/
 render.yaml                                           # 更新
 spec/
   services/
-    active_storage_backblaze_b2_config_validator_spec.rb # 更新または追加
+    active_storage_s3_config_validator_spec.rb          # 更新
   config/
     production_active_storage_config_spec.rb           # 更新
     storage_config_spec.rb                             # 追加

--- a/.steering/20260531-issue-270-backblaze-b2-storage/requirements.md
+++ b/.steering/20260531-issue-270-backblaze-b2-storage/requirements.md
@@ -1,0 +1,65 @@
+# 要求内容
+
+## 概要
+
+Issue #270「本番環境のActive Storage保存先をBackblaze B2へ切り替える」を解決するため、production の Active Storage 保存先を Backblaze B2（S3互換）へ移行し、本番での書影アップロードを成立させる。
+
+## 背景
+
+- 現在の production は S3 前提の設定になっているが、本番環境では AWS 系の環境変数が用意されていない。
+- `DATABASE_URL` はデータベース接続先であり、Active Storage のファイル実体を保存する場所ではない。
+- Backblaze B2 は S3 互換で利用できるため、保存先を B2 に切り替えることで本番のアップロード機能を成立させられる。
+
+## 実装対象の機能
+
+### 1. production の Active Storage を Backblaze B2 に切り替える
+- production の Active Storage サービスを Backblaze B2 用に固定する。
+- B2 用の必須環境変数を検証し、不足時は起動失敗にする。
+- AWS 前提の環境変数名を B2 向けに整理する。
+
+### 2. 本番デプロイ設定の更新
+- Render の環境変数定義を B2 用に更新する。
+- 設定手順や運用メモに B2 の必要項目を反映する。
+
+### 3. 回帰テストの追加
+- production 設定が B2 向け validator と Backblaze B2 サービスを参照することをテスト化する。
+- B2 必須環境変数の検証をテスト化する。
+
+## 受け入れ条件
+
+### production の Active Storage 切り替え
+- [ ] production で Backblaze B2 向けの必須環境変数が欠けると起動時に例外が発生する。
+- [ ] production で Active Storage は Backblaze B2 サービスに固定される。
+- [ ] B2 用の環境変数名がコードとドキュメントで一致している。
+
+### 本番デプロイ設定
+- [ ] Render の環境変数一覧が B2 用に更新されている。
+- [ ] 既存の書籍登録・編集・表示機能に回帰がない。
+
+### 回帰テスト
+- [ ] B2 必須環境変数チェックのテストが追加される。
+- [ ] production 設定の切り替えを確認するテストが追加される。
+- [ ] RSpec / RuboCop が通過する。
+
+## 成功指標
+
+- production 起動時に B2 設定不備を即検知できる。
+- 本番でアップロードした書影が Backblaze B2 に保存される前提がコード上で保証される。
+- 環境変数名とドキュメントの不整合がない。
+
+## スコープ外
+
+以下はこのフェーズでは実装しません:
+
+- 既存の Active Storage blob の一括移行ツール
+- Render ダッシュボード上での実際の環境変数入力作業
+- 画像表示 UI の追加改善
+
+## 参照ドキュメント
+
+- `docs/architecture.md` - アーキテクチャ設計書
+- `docs/development-guidelines.md` - 開発ガイドライン
+- `config/environments/production.rb` - 本番設定
+- `config/storage.yml` - Active Storage 設定
+- `render.yaml` - Render デプロイ設定
+- `README.md` - 環境変数・デプロイ手順

--- a/.steering/20260531-issue-270-backblaze-b2-storage/tasklist.md
+++ b/.steering/20260531-issue-270-backblaze-b2-storage/tasklist.md
@@ -1,0 +1,82 @@
+# タスクリスト
+
+## 🚨 タスク完全完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+### 必須ルール
+- **全てのタスクを`[x]`にすること**
+- 未完了タスク（`[ ]`）を残したまま作業を終了しない
+
+---
+
+## フェーズ1: 事前整理
+
+- [x] issue #270 の現行 Active Storage 設定を確認する
+  - [x] `production.rb`, `storage.yml`, `render.yaml`, `README.md` の B2 影響範囲を確認する
+  - [x] 既存の validator/spec を確認して変更点を整理する
+
+- [x] B2 切り替え方針を文書化する
+  - [x] B2 用の env var 名と endpoint 方針を決める
+  - [x] 必要なドキュメント更新範囲を確定する
+
+## フェーズ2: 実装
+
+- [x] production の Active Storage を Backblaze B2 に切り替える
+  - [x] B2 用 validator を実装する
+  - [x] `config/environments/production.rb` の service 設定を更新する
+  - [x] `config/storage.yml` を B2 用に更新する
+
+- [x] 本番デプロイ設定を B2 用に更新する
+  - [x] `render.yaml` の環境変数を更新する
+  - [x] `README.md` と関連ドキュメントの案内を更新する
+
+## フェーズ3: テスト
+
+- [x] 回帰テストを追加する
+  - [x] B2 validator の spec を更新または追加する
+  - [x] production 設定の spec を更新する
+  - [x] storage.yml の設定 spec を追加する
+
+## フェーズ4: 品質チェック
+
+- [x] RSpec を実行して通過を確認する
+- [x] RuboCop を実行して通過を確認する
+
+## フェーズ5: 振り返り
+
+- [x] tasklist に振り返りを記入する
+
+---
+
+## 実装後の振り返り
+
+### 実装完了日
+2026-05-31
+
+### 計画と実績の差分
+
+**計画と異なった点**:
+- Backblaze B2 用の endpoint 変数を必須項目に追加した。
+- production の service 名を `:backblaze` に変更し、`storage.yml` も B2 用に切り替えた。
+
+**新たに必要になったタスク**:
+- `spec/config/storage_config_spec.rb` を追加し、`storage.yml` の B2 定義を直接検証した。
+- ドキュメントの Active Storage 反映手順を Backblaze B2 前提に更新した。
+
+**技術的理由でスキップしたタスク**（該当する場合のみ）:
+- なし
+
+### 学んだこと
+
+**技術的な学び**:
+- Backblaze B2 は S3 互換でも endpoint と `force_path_style` を明示しておくと設定意図が読みやすい。
+- production 起動時の fail-fast と storage.yml の直接 spec を組み合わせると、設定ずれを早く検知できる。
+
+**プロセス上の改善点**:
+- 先に focused spec を回してから全体の RSpec / RuboCop に広げると、修正範囲を狭く保てる。
+- steering の tasklist を実装後すぐ更新すると、後続の振り返りがそのまま書ける。
+
+### 次回への改善提案
+- 環境変数名を切り替える変更では、README だけでなく deployment workflow まで一括で追従させる。
+- S3 互換ストレージの切り替えでは、service 名・endpoint・path style の 3 点をセットで spec 化する。

--- a/README.md
+++ b/README.md
@@ -333,14 +333,15 @@ Renderダッシュボードで以下の環境変数を設定してください�
 
 #### Active Storage（S3）を有効化する場合に追加で必要な環境変数
 
-以下 4 つは `feature/#25-active-storage-setup` を反映する場合のみ必須です。
+以下 5 つは `feature/#25-active-storage-setup` を反映する場合のみ必須です。
 
 | 環境変数 | 説明 | 取得方法 |
 |----------|------|---------|
-| `AWS_ACCESS_KEY_ID` | Active Storage (S3) のアクセスキー | AWS IAM ユーザーのアクセスキー |
-| `AWS_SECRET_ACCESS_KEY` | Active Storage (S3) のシークレットキー | AWS IAM ユーザーのシークレットキー |
-| `AWS_REGION` | S3 バケットのリージョン | 例: `ap-northeast-1` |
-| `AWS_BUCKET` | 保存先 S3 バケット名 | 作成した S3 バケット名 |
+| `B2_ACCESS_KEY_ID` | Active Storage (Backblaze B2) のアクセスキー | Backblaze B2 の S3 アクセスキー ID |
+| `B2_SECRET_ACCESS_KEY` | Active Storage (Backblaze B2) のシークレットキー | Backblaze B2 のアプリケーションキー |
+| `B2_REGION` | B2 互換 S3 のリージョン | 例: `us-west-004` |
+| `B2_BUCKET` | 保存先 B2 バケット名 | 作成した B2 バケット名 |
+| `B2_ENDPOINT` | B2 の S3 互換エンドポイント | 例: `https://s3.us-west-004.backblazeb2.com` |
 
 ### セットアップ手順
 
@@ -379,14 +380,15 @@ Renderのサービスダッシュボード → **Environment** タブで以下�
 | `RAILS_LOG_TO_STDOUT` | `true` |
 | `RAILS_SERVE_STATIC_FILES` | `true` |
 
-Active Storage（S3）有効化時のみ、以下も設定してください。
+Active Storage（Backblaze B2 / S3互換）有効化時のみ、以下も設定してください。
 
 | キー | 値 |
 |------|----|
-| `AWS_ACCESS_KEY_ID` | AWS IAM アクセスキー |
-| `AWS_SECRET_ACCESS_KEY` | AWS IAM シークレットキー |
-| `AWS_REGION` | S3 のリージョン |
-| `AWS_BUCKET` | S3 バケット名 |
+| `B2_ACCESS_KEY_ID` | Backblaze B2 の S3 アクセスキー ID |
+| `B2_SECRET_ACCESS_KEY` | Backblaze B2 のアプリケーションキー |
+| `B2_REGION` | B2 のリージョン |
+| `B2_BUCKET` | B2 バケット名 |
+| `B2_ENDPOINT` | B2 の S3 互換エンドポイント |
 
 #### 4. 初回デプロイを実行する
 

--- a/README.md
+++ b/README.md
@@ -331,9 +331,9 @@ Renderダッシュボードで以下の環境変数を設定してください�
 | `DATABASE_URL` | NeonのPostgreSQL接続文字列 | Neonダッシュボード → Connection Details → Connection String（末尾に `?sslmode=require` を付与） |
 | `RAILS_MASTER_KEY` | Railsのマスターキー | `config/master.key` の内容（本番用は別途生成推奨） |
 
-#### Active Storage（S3）を有効化する場合に追加で必要な環境変数
+#### production で Active Storage（Backblaze B2 / S3互換）に必須の環境変数
 
-以下 5 つは `feature/#25-active-storage-setup` を反映する場合のみ必須です。
+production では起動時に B2 必須環境変数を検証するため、以下 5 つは必須です。
 
 | 環境変数 | 説明 | 取得方法 |
 |----------|------|---------|
@@ -380,7 +380,7 @@ Renderのサービスダッシュボード → **Environment** タブで以下�
 | `RAILS_LOG_TO_STDOUT` | `true` |
 | `RAILS_SERVE_STATIC_FILES` | `true` |
 
-Active Storage（Backblaze B2 / S3互換）有効化時のみ、以下も設定してください。
+production では以下も必ず設定してください。
 
 | キー | 値 |
 |------|----|

--- a/app/services/active_storage_s3_config_validator.rb
+++ b/app/services/active_storage_s3_config_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ActiveStorageS3ConfigValidator
-  REQUIRED_ENV_KEYS = %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION AWS_S3_BUCKET].freeze
+  REQUIRED_ENV_KEYS = %w[B2_ACCESS_KEY_ID B2_SECRET_ACCESS_KEY B2_REGION B2_BUCKET B2_ENDPOINT].freeze
 
   def self.missing_keys(env = ENV)
     REQUIRED_ENV_KEYS.select { |key| env[key].blank? }
@@ -11,6 +11,6 @@ class ActiveStorageS3ConfigValidator
     missing = missing_keys(env)
     return if missing.empty?
 
-    raise KeyError, "Missing required Active Storage S3 env vars: #{missing.join(', ')}"
+    raise KeyError, "Missing required Active Storage B2 env vars: #{missing.join(', ')}"
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,9 +115,9 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Active Storage: production では S3 を必須化する。
+  # Active Storage: production では Backblaze B2 を必須化する。
   ActiveStorageS3ConfigValidator.assert!
-  config.active_storage.service = :amazon
+  config.active_storage.service = :backblaze
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,12 +6,14 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-amazon:
+backblaze:
   service: S3
-  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
-  region: <%= ENV["AWS_REGION"] %>
-  bucket: <%= ENV["AWS_S3_BUCKET"] %>
+  access_key_id: <%= ENV["B2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["B2_SECRET_ACCESS_KEY"] %>
+  region: <%= ENV["B2_REGION"] %>
+  bucket: <%= ENV["B2_BUCKET"] %>
+  endpoint: <%= ENV["B2_ENDPOINT"] %>
+  force_path_style: true
 
 # Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
 # microsoft:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ config.active_record.default_timezone = :local # DBへの保存もローカル�
 - **Active Storage（S3）を主系として使用**: `Book` の `has_one_attached :cover_image` でユーザーアップロードを保持
 - `books.cover_image_url` は外部URL書影の補助経路として併用
 - 表示時は `cover_image` 添付を優先し、未添付時に `cover_image_url` を利用
-- production では S3 必須（`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_S3_BUCKET`）。不足時は fail-fast で起動失敗
+- production では Backblaze B2（S3互換）必須（`B2_ACCESS_KEY_ID`, `B2_SECRET_ACCESS_KEY`, `B2_REGION`, `B2_BUCKET`, `B2_ENDPOINT`）。不足時は fail-fast で起動失敗
 - 画像読み込み失敗時は UI でプレースホルダー表示へフォールバック
 
 ```ruby
@@ -196,7 +196,7 @@ end
 
 | 項目 | 方針 |
 |------|------|
-| production ストレージ | `:amazon` 固定（`:local` フォールバック禁止） |
+| production ストレージ | `:backblaze` 固定（`:local` フォールバック禁止） |
 | 環境変数不足 | 起動時に例外を発生させ、誤設定状態で運用しない |
 | 外部URL書影 | リンク切れや取得失敗の可能性があるため UI フォールバックを適用 |
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -313,16 +313,17 @@ services:
 
 > **Note**: `sync: false` の環境変数は Render Dashboard の Environment タブで手動設定してください。
 
-### Active Storage（S3）反映時の事前チェック（Issue #112 対応）
+### Active Storage（Backblaze B2 / S3互換）反映時の事前チェック（Issue #112 対応）
 
 `feature/#25-active-storage-setup` を main にマージする前に、以下を必ず実施してください。
 
-1. AWS 側で S3 バケットを作成済みであること
+1. Backblaze B2 側で S3 互換バケットを作成済みであること
 2. Render Dashboard の Environment に次を設定済みであること
-    - `AWS_ACCESS_KEY_ID`
-    - `AWS_SECRET_ACCESS_KEY`
-    - `AWS_REGION`（例: `ap-northeast-1`）
-    - `AWS_BUCKET`
+  - `B2_ACCESS_KEY_ID`
+  - `B2_SECRET_ACCESS_KEY`
+  - `B2_REGION`（例: `us-west-004`）
+  - `B2_BUCKET`
+  - `B2_ENDPOINT`（例: `https://s3.us-west-004.backblazeb2.com`）
 3. `render.yaml` の `sync: false` は「値は Git 管理せず、Render 側で手動設定する」意味であることを理解していること
 
 上記が未実施のまま `feature/#25-active-storage-setup` をマージすると、本番起動時に環境変数不足で起動不能になるリスクがあります。
@@ -337,7 +338,7 @@ services:
 
 ### PR レビュー時チェックリスト（Active Storage 反映時）
 
-- [ ] Render Dashboard に `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `AWS_BUCKET` が設定済み
+- [ ] Render Dashboard に `B2_ACCESS_KEY_ID`, `B2_SECRET_ACCESS_KEY`, `B2_REGION`, `B2_BUCKET`, `B2_ENDPOINT` が設定済み
 - [ ] `feature/#25-active-storage-setup` の反映後に `/up` が正常応答することを確認済み
 - [ ] `feature/#26-cover-image-upload` は `feature/#25` のデプロイ確認後にマージする
 - [ ] `sync: false` の環境変数が「手動設定前提」であることをレビューで確認済み

--- a/render.yaml
+++ b/render.yaml
@@ -29,11 +29,13 @@ services:
         sync: false
       - key: RAKUTEN_APPLICATION_ID
         sync: false
-      - key: AWS_ACCESS_KEY_ID
+      - key: B2_ACCESS_KEY_ID
         sync: false
-      - key: AWS_SECRET_ACCESS_KEY
+      - key: B2_SECRET_ACCESS_KEY
         sync: false
-      - key: AWS_REGION
+      - key: B2_REGION
         sync: false
-      - key: AWS_S3_BUCKET
+      - key: B2_BUCKET
+        sync: false
+      - key: B2_ENDPOINT
         sync: false

--- a/spec/config/production_active_storage_config_spec.rb
+++ b/spec/config/production_active_storage_config_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe 'production Active Storage config' do
-  it 'production 設定で validator が呼ばれ、サービスが :amazon に固定されている' do
+  it 'production 設定で validator が呼ばれ、サービスが :backblaze に固定されている' do
     config_text = Rails.root.join('config/environments/production.rb').read
 
     expect(config_text).to include('ActiveStorageS3ConfigValidator.assert!')
-    expect(config_text).to include('config.active_storage.service = :amazon')
+    expect(config_text).to include('config.active_storage.service = :backblaze')
     expect(config_text).not_to include(':local')
   end
 end

--- a/spec/config/storage_config_spec.rb
+++ b/spec/config/storage_config_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Active Storage storage config' do
+  it 'production 用に Backblaze B2 の service 定義がある' do
+    config_text = Rails.root.join('config/storage.yml').read
+
+    expect(config_text).to include('backblaze:')
+    expect(config_text).to include('service: S3')
+    expect(config_text).to include('access_key_id: <%= ENV["B2_ACCESS_KEY_ID"] %>')
+    expect(config_text).to include('secret_access_key: <%= ENV["B2_SECRET_ACCESS_KEY"] %>')
+    expect(config_text).to include('region: <%= ENV["B2_REGION"] %>')
+    expect(config_text).to include('bucket: <%= ENV["B2_BUCKET"] %>')
+    expect(config_text).to include('endpoint: <%= ENV["B2_ENDPOINT"] %>')
+    expect(config_text).to include('force_path_style: true')
+  end
+end

--- a/spec/services/active_storage_s3_config_validator_spec.rb
+++ b/spec/services/active_storage_s3_config_validator_spec.rb
@@ -5,10 +5,11 @@ require 'rails_helper'
 RSpec.describe ActiveStorageS3ConfigValidator do
   let(:valid_env) do
     {
-      'AWS_ACCESS_KEY_ID' => 'access',
-      'AWS_SECRET_ACCESS_KEY' => 'secret',
-      'AWS_REGION' => 'ap-northeast-1',
-      'AWS_S3_BUCKET' => 'bucket-name'
+      'B2_ACCESS_KEY_ID' => 'access',
+      'B2_SECRET_ACCESS_KEY' => 'secret',
+      'B2_REGION' => 'us-west-004',
+      'B2_BUCKET' => 'bucket-name',
+      'B2_ENDPOINT' => 'https://s3.us-west-004.backblazeb2.com'
     }
   end
 
@@ -18,9 +19,9 @@ RSpec.describe ActiveStorageS3ConfigValidator do
     end
 
     it '不足しているキーを返す' do
-      env = valid_env.merge('AWS_REGION' => '', 'AWS_S3_BUCKET' => nil)
+      env = valid_env.merge('B2_REGION' => '', 'B2_ENDPOINT' => nil)
 
-      expect(described_class.missing_keys(env)).to contain_exactly('AWS_REGION', 'AWS_S3_BUCKET')
+      expect(described_class.missing_keys(env)).to contain_exactly('B2_REGION', 'B2_ENDPOINT')
     end
   end
 
@@ -30,10 +31,10 @@ RSpec.describe ActiveStorageS3ConfigValidator do
     end
 
     it '不足キーがある場合は KeyError を発生させる' do
-      env = valid_env.merge('AWS_ACCESS_KEY_ID' => nil)
+      env = valid_env.merge('B2_ACCESS_KEY_ID' => nil)
 
       expect { described_class.assert!(env) }
-        .to raise_error(KeyError, /Missing required Active Storage S3 env vars: AWS_ACCESS_KEY_ID/)
+        .to raise_error(KeyError, /Missing required Active Storage B2 env vars: B2_ACCESS_KEY_ID/)
     end
   end
 end


### PR DESCRIPTION
## 概要
production の Active Storage 保存先を Backblaze B2（S3互換）へ切り替えました。

## 変更内容
- production の Active Storage サービスを `:backblaze` に変更
- Active Storage 設定を B2 用環境変数（`B2_*`）へ移行
- Backblaze B2 必須環境変数の fail-fast 検証を実装
- Render/README/開発フロー/アーキテクチャ文書を B2 前提に更新
- 回帰テストを追加（validator / production config / storage config）
- steering ドキュメントを追加・更新

## テスト結果
- `bundle exec rspec` : pass（629 examples, 0 failures）
- `bundle exec rubocop` : pass（103 files inspected, no offenses）

Closes #270