### PR TITLE
#287 【機能追加】一覧画面でメモの内容で検索できるようにする（メモ一覧を表示）

### DIFF
--- a/.steering/20260606-issue287-memo-search/design.md
+++ b/.steering/20260606-issue287-memo-search/design.md
@@ -1,0 +1,80 @@
+# 設計ドキュメント: Issue #287 メモ検索機能
+
+## アーキテクチャ方針
+既存の本の一覧検索と同じパターンに倣いつつ、「メモ一覧」という別の表示形式を追加する。
+
+## UI/UX 設計
+
+### 表示切り替え
+- 現在の検索フォームは本の属性（タイトル、著者等）を検索するもの
+- メモ検索は別のフォームとして一覧上部に追加
+- `memo_keyword` パラメータが存在する場合にメモ一覧を表示（本の一覧の代わり）
+- `memo_keyword` がない場合は従来通り本の一覧を表示
+
+### メモ一覧の表示
+各メモカードに以下を表示：
+- 所属する本のタイトル（`books#show` へのリンク）
+- ページ番号（あれば）
+- メモ内容（既存の装飾レンダリングを利用）
+- 作成日時（`l(memo.created_at, format: :long)`）
+
+## モデル設計
+
+### BookMemo スコープ追加
+```ruby
+scope :content_like, ->(query) { where("content ILIKE ?", "%#{sanitize_sql_like(query)}%") }
+```
+
+## コントローラー設計
+
+### BooksController#index の変更
+```ruby
+def index
+  @search_params = build_search_params(params)
+  @search_active = @search_params.values.any?(&:present?)
+
+  if params[:memo_keyword].present?
+    # メモ検索モード
+    @memo_keyword = params[:memo_keyword]
+    @memo_search_active = true
+    book_ids = current_user.books.ids
+    @memos = BookMemo.where(book_id: book_ids)
+                     .content_like(@memo_keyword)
+                     .includes(:book)
+                     .order(created_at: :desc)
+    @books = current_user.books.none  # 本の一覧は表示しない
+  else
+    # 通常の本の一覧モード
+    @memo_keyword = nil
+    @memo_search_active = false
+    @memos = []
+    @books = current_user.books.filtered_for_index(@search_params)
+  end
+end
+```
+
+## ビュー設計
+
+### index.html.erb への追加
+1. メモ検索フォーム（既存の本の検索フォームの下に追加）
+2. メモ一覧パーシャルの呼び出し（`@memo_search_active` が true の場合）
+
+### _memo_search_results.html.erb
+メモカードの一覧を表示するパーシャル。
+
+## CSS 設計（BEM）
+
+```css
+.memo-list { }
+.memo-list__item { }
+.memo-card { }
+.memo-card__book-title { }
+.memo-card__page-number { }
+.memo-card__content { }
+.memo-card__meta { }
+```
+
+## セキュリティ考慮事項
+- `current_user.books.ids` で自分の本のみを検索対象にすることで、他ユーザーのメモにアクセスされない
+- `sanitize_sql_like` で SQLインジェクション対策
+- メモ内容の表示は既存の `render_memo_content` ヘルパーを流用（XSS対策済み）

--- a/.steering/20260606-issue287-memo-search/requirements.md
+++ b/.steering/20260606-issue287-memo-search/requirements.md
@@ -1,0 +1,38 @@
+# Issue #287: 一覧画面でメモの内容で検索できるようにする（メモ一覧を表示）
+
+## 要件
+
+### 背景
+現在の一覧画面は本単位での表示となっているが、過去に書いたメモを内容から探したいケースがある。
+
+### 機能要件
+1. 一覧画面（`books#index`）にメモ検索フォームを追加する
+2. 入力されたキーワードをメモ本文（`book_memos.content`）で部分一致検索（ILIKE）する
+3. 検索結果はメモの一覧形式で表示する（本の一覧ではない）
+4. メモ一覧には以下の情報を表示する：
+   - メモ内容（content）
+   - ページ番号（page_number）
+   - 所属する本のタイトル（書籍詳細ページへのリンク）
+   - 作成日時
+
+### 非機能要件
+- 既存の本の一覧検索機能との共存（別タブや別セクションとして表示）
+- 認証済みユーザー自身のメモのみ検索対象
+- SQLインジェクション対策（`sanitize_sql_like` を使用）
+- BEM記法でのCSS追加
+
+## 対象ファイル
+
+### 新規作成
+- `app/views/books/_memo_search_results.html.erb`（メモ一覧パーシャル）
+
+### 修正
+- `app/models/book_memo.rb`（`content_like` スコープ追加）
+- `app/controllers/books_controller.rb`（`index`アクションにメモ検索ロジック追加）
+- `app/views/books/index.html.erb`（メモ検索フォームとメモ一覧表示の追加）
+- `app/assets/stylesheets/books.css`（メモ一覧のスタイル追加）
+
+### テスト
+- `spec/models/book_memo_spec.rb`（`content_like`スコープのテスト追加）
+- `spec/requests/books_index_spec.rb`（メモ検索のリクエストスペック追加）
+- `spec/system/books/memo_search_spec.rb`（E2Eスペック新規作成）

--- a/.steering/20260606-issue287-memo-search/tasklist.md
+++ b/.steering/20260606-issue287-memo-search/tasklist.md
@@ -1,0 +1,16 @@
+# タスクリスト: Issue #287 メモ検索機能
+
+## タスク一覧
+
+- [ ] ブランチ作成 (`feature/#287-memo-search`)
+- [ ] BookMemo モデルに `content_like` スコープを追加
+- [ ] BooksController の `index` アクションにメモ検索ロジックを追加
+- [ ] `app/views/books/index.html.erb` にメモ検索フォームを追加
+- [ ] `app/views/books/_memo_search_results.html.erb` を新規作成
+- [ ] `app/assets/stylesheets/books.css` にメモ一覧のスタイルを追加
+- [ ] `spec/models/book_memo_spec.rb` に `content_like` スコープのテストを追加
+- [ ] `spec/requests/books_index_spec.rb` にメモ検索のリクエストスペックを追加
+- [ ] `spec/system/books/memo_search_spec.rb` を新規作成
+- [ ] `bundle exec rspec` を実行してテストが通ることを確認
+- [ ] `bundle exec rubocop` を実行してエラーがないことを確認
+- [ ] コミット・プッシュ・PR作成

--- a/.steering/20260606-issue287-memo-search/tasklist.md
+++ b/.steering/20260606-issue287-memo-search/tasklist.md
@@ -2,15 +2,29 @@
 
 ## タスク一覧
 
-- [ ] ブランチ作成 (`feature/#287-memo-search`)
-- [ ] BookMemo モデルに `content_like` スコープを追加
-- [ ] BooksController の `index` アクションにメモ検索ロジックを追加
-- [ ] `app/views/books/index.html.erb` にメモ検索フォームを追加
-- [ ] `app/views/books/_memo_search_results.html.erb` を新規作成
-- [ ] `app/assets/stylesheets/books.css` にメモ一覧のスタイルを追加
-- [ ] `spec/models/book_memo_spec.rb` に `content_like` スコープのテストを追加
-- [ ] `spec/requests/books_index_spec.rb` にメモ検索のリクエストスペックを追加
-- [ ] `spec/system/books/memo_search_spec.rb` を新規作成
-- [ ] `bundle exec rspec` を実行してテストが通ることを確認
-- [ ] `bundle exec rubocop` を実行してエラーがないことを確認
-- [ ] コミット・プッシュ・PR作成
+- [x] ブランチ作成 (`feature/#287-memo-search`)
+- [x] BookMemo モデルに `content_like` スコープを追加
+- [x] BooksController の `index` アクションにメモ検索ロジックを追加
+- [x] `app/views/books/index.html.erb` にメモ検索フォームを追加
+- [x] `app/views/books/_memo_search_results.html.erb` を新規作成
+- [x] `app/assets/stylesheets/books.css` にメモ一覧のスタイルを追加
+- [x] `spec/models/book_memo_spec.rb` に `content_like` スコープのテストを追加
+- [x] `spec/requests/books_index_spec.rb` にメモ検索のリクエストスペックを追加
+- [x] `spec/system/books/memo_search_spec.rb` を新規作成
+- [x] `bundle exec rspec` を実行してテストが通ることを確認
+- [x] `bundle exec rubocop` を実行してエラーがないことを確認
+- [x] コミット・プッシュ・PR作成
+
+## 振り返り
+
+### 実装について
+- `memo_keyword` パラメータの有無でメモ一覧と本の一覧を切り替える設計にした
+- `current_user.books.ids` でアクセス制御を担保し、他ユーザーのメモを検索対象から除外
+- 既存の `render_book_memo_content` ヘルパーを流用して装飾記法をメモ一覧にも適用
+- メモ検索フォームとクリアリンクに一意のIDを付与し、システムスペックのアンビギュアス問題を回避
+
+### 発見した問題
+- mainブランチ取り込み時点で `search_filter_autocomplete_spec.rb`（#304追加）と `suggestions` 関連テストが既に失敗していた（今回の変更とは無関係）
+
+### PR
+- PR #308: https://github.com/liverpl1920/Yomikiri/pull/308

--- a/app/assets/stylesheets/books.css
+++ b/app/assets/stylesheets/books.css
@@ -1777,3 +1777,140 @@
   flex-shrink: 0;
 }
 
+/* ---- メモ検索フォーム ---- */
+.books-index__memo-search {
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.books-index__memo-search-fields {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.books-index__memo-search-input {
+  flex: 1;
+  min-width: 180px;
+}
+
+/* ---- メモ検索結果 ---- */
+.memo-search-results {
+  margin-top: var(--spacing-lg);
+}
+
+.memo-search-results__summary {
+  margin-bottom: var(--spacing-md);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.memo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.memo-list__item {
+  display: block;
+}
+
+.memo-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  transition: box-shadow 0.2s ease;
+}
+
+.memo-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.memo-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.memo-card__book-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.memo-card__book-link:hover .memo-card__book-title {
+  text-decoration: underline;
+  color: var(--color-primary);
+}
+
+.memo-card__book-title {
+  font-weight: 600;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.memo-card__page-number {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.1rem 0.4rem;
+}
+
+.memo-card__content {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  line-height: 1.7;
+  margin-bottom: var(--spacing-sm);
+}
+
+.memo-card__content p {
+  margin: 0 0 0.5rem;
+}
+
+.memo-card__content p:last-child {
+  margin-bottom: 0;
+}
+
+.memo-card__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.memo-card__date {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.memo-card__edited {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .books-index__memo-search {
+    padding: var(--spacing-md);
+  }
+
+  .books-index__memo-search-fields {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .memo-card {
+    padding: var(--spacing-md);
+  }
+}
+
+

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -16,7 +16,19 @@ class BooksController < ApplicationController
   def index
     @search_params = normalized_index_search_params
     @search_active = @search_params.values.any?(&:present?)
-    @books = current_user.books.with_attached_cover_image.filtered_for_index(@search_params)
+    @memo_keyword = params[:memo_keyword].presence
+    @memo_search_active = @memo_keyword.present?
+
+    if @memo_search_active
+      @memos = BookMemo.where(book_id: current_user.books.ids)
+                       .content_like(@memo_keyword)
+                       .includes(:book)
+                       .order(created_at: :desc)
+      @books = current_user.books.none
+    else
+      @memos = []
+      @books = current_user.books.with_attached_cover_image.filtered_for_index(@search_params)
+    end
   end
 
   def new

--- a/app/models/book_memo.rb
+++ b/app/models/book_memo.rb
@@ -8,6 +8,7 @@ class BookMemo < ApplicationRecord
   validates :page_number, length: { maximum: PAGE_NUMBER_MAX_LENGTH }, allow_blank: true
 
   scope :latest_first, -> { order(created_at: :desc) }
+  scope :content_like, ->(query) { where("content ILIKE ?", "%#{sanitize_sql_like(query)}%") }
 
   def edited?
     (updated_at - created_at) > 1.second

--- a/app/views/books/_memo_search_results.html.erb
+++ b/app/views/books/_memo_search_results.html.erb
@@ -1,0 +1,44 @@
+<% if memos.empty? %>
+  <div class="books-empty">
+    <div class="books-empty__icon" aria-hidden="true">📝</div>
+    <h2 class="books-empty__title">メモが見つかりません</h2>
+    <p class="books-empty__description">
+      「<%= memo_keyword %>」に一致するメモはありません。<br>
+      キーワードを変えてお試しください。
+    </p>
+    <%= link_to "メモ検索をクリア", books_path, class: "btn btn--secondary btn--lg" %>
+  </div>
+<% else %>
+  <div class="memo-search-results">
+    <p class="memo-search-results__summary">
+      「<strong><%= memo_keyword %></strong>」の検索結果：<%= memos.size %> 件
+    </p>
+    <ul class="memo-list" aria-label="メモ一覧">
+      <% memos.each do |memo| %>
+        <li class="memo-list__item">
+          <article class="memo-card">
+            <header class="memo-card__header">
+              <%= link_to book_path(memo.book), class: "memo-card__book-link" do %>
+                <span class="memo-card__book-title">📚 <%= memo.book.title %></span>
+              <% end %>
+              <% if memo.page_number.present? %>
+                <span class="memo-card__page-number">p. <%= memo.page_number %></span>
+              <% end %>
+            </header>
+            <div class="memo-card__content">
+              <%= render_book_memo_content(memo.content) %>
+            </div>
+            <footer class="memo-card__meta">
+              <time class="memo-card__date" datetime="<%= memo.created_at.iso8601 %>">
+                <%= l(memo.created_at, format: :long) %>
+              </time>
+              <% if memo.edited? %>
+                <span class="memo-card__edited">（編集済み）</span>
+              <% end %>
+            </footer>
+          </article>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -133,7 +133,28 @@
       </div>
     <% end %>
 
-    <% if @books.empty? %>
+    <%# メモ検索フォーム %>
+    <%= form_with url: books_path, method: :get, local: true,
+                  id: "memo-search-form",
+                  class: "books-index__memo-search" do %>
+      <div class="books-index__memo-search-fields">
+        <label for="memo_keyword" class="books-index__search-label">メモ検索</label>
+        <%= text_field_tag :memo_keyword, @memo_keyword,
+              id: "memo_keyword",
+              class: "books-index__search-input books-index__memo-search-input",
+              placeholder: "メモ内容のキーワードで検索" %>
+        <%= submit_tag "メモを検索", class: "btn btn--secondary",
+              id: "memo-search-submit" %>
+        <% if @memo_search_active %>
+          <%= link_to "クリア", books_path, class: "btn btn--ghost",
+                id: "memo-search-clear" %>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% if @memo_search_active %>
+      <%= render 'memo_search_results', memos: @memos, memo_keyword: @memo_keyword %>
+    <% elsif @books.empty? %>
       <%# Empty State %>
       <div class="books-empty">
         <div class="books-empty__icon" aria-hidden="true">📚</div>
@@ -151,7 +172,7 @@
           <%= link_to "最初の本を登録して始める", new_book_path, class: "btn btn--primary btn--lg" %>
         <% end %>
       </div>
-    <% else %>
+    <% elsif !@memo_search_active %>
       <ul class="book-list" aria-label="積読一覧">
         <% @books.each do |book| %>
         <li class="book-list__item">

--- a/spec/models/book_memo_spec.rb
+++ b/spec/models/book_memo_spec.rb
@@ -61,7 +61,28 @@ RSpec.describe BookMemo, type: :model do
         expect(book.book_memos.latest_first).to eq([ new_memo, old_memo ])
       end
     end
+
+    describe '.content_like' do
+      let(:book) { create(:book) }
+      let!(:matching_memo) { create(:book_memo, book: book, content: '重要なポイントはここです') }
+      let!(:other_memo) { create(:book_memo, book: book, content: '別の内容') }
+
+      it '部分一致するメモを返す' do
+        expect(BookMemo.content_like('重要')).to include(matching_memo)
+        expect(BookMemo.content_like('重要')).not_to include(other_memo)
+      end
+
+      it '大文字小文字を区別しない' do
+        memo = create(:book_memo, book: book, content: 'Ruby on Rails')
+        expect(BookMemo.content_like('ruby')).to include(memo)
+      end
+
+      it 'キーワードに一致しない場合は空を返す' do
+        expect(BookMemo.content_like('存在しないキーワード')).to be_empty
+      end
+    end
   end
+
 
   describe 'インスタンスメソッド' do
     describe '#edited?' do

--- a/spec/requests/books_index_spec.rb
+++ b/spec/requests/books_index_spec.rb
@@ -171,4 +171,77 @@ RSpec.describe 'Books index search', type: :request do
       end
     end
   end
+
+  describe 'GET /books?memo_keyword=xxx （メモ検索）' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:book) { create(:book, user: user, title: 'テスト書籍', status: :reading, deadline: Date.current + 5) }
+    let(:other_book) { create(:book, user: other_user, title: '他ユーザーの本', status: :reading) }
+
+    context '未ログインの場合' do
+      it 'ログイン画面へリダイレクトされる' do
+        get books_path, params: { memo_keyword: 'テスト' }
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      let!(:matching_memo) { create(:book_memo, book: book, content: 'ここが重要なポイントです') }
+      let!(:other_memo) { create(:book_memo, book: book, content: '別の内容のメモ') }
+      let!(:other_user_memo) { create(:book_memo, book: other_book, content: '重要な他ユーザーメモ') }
+
+      it '200を返す' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'キーワードに一致するメモ内容が表示される' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response.body).to include('ここが重要なポイントです')
+      end
+
+      it 'キーワードに一致しないメモは表示されない' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response.body).not_to include('別の内容のメモ')
+      end
+
+      it '他ユーザーのメモは検索対象外になる' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response.body).not_to include('重要な他ユーザーメモ')
+      end
+
+      it 'メモに紐づく本のタイトルが表示される' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response.body).to include(book.title)
+      end
+
+      it '検索結果0件の場合はメモが見つからないメッセージを表示する' do
+        get books_path, params: { memo_keyword: '存在しないキーワード' }
+
+        expect(response.body).to include('メモが見つかりません')
+      end
+
+      it 'memo_keywordがない場合は本の一覧を表示する' do
+        get books_path
+
+        doc = Nokogiri::HTML.parse(response.body)
+        expect(doc.css('.book-card__title')).not_to be_empty
+        expect(response.body).not_to include('メモが見つかりません')
+      end
+
+      it '検索キーワードがフォームに保持される' do
+        get books_path, params: { memo_keyword: '重要' }
+
+        expect(response.body).to include('value="重要"')
+      end
+    end
+  end
 end

--- a/spec/system/books/memo_search_spec.rb
+++ b/spec/system/books/memo_search_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'メモ検索機能', type: :system do
+  let!(:user) { create(:user) }
+  let!(:book) { create(:book, user: user, title: 'テスト書籍', status: :reading, deadline: Date.current + 5) }
+  let!(:other_user) { create(:user) }
+  let!(:other_book) { create(:book, user: other_user, title: '他ユーザーの本', status: :reading) }
+
+  before do
+    driven_by(:rack_test)
+    rack_test_sign_in(user)
+  end
+
+  describe 'メモ検索フォームの表示' do
+    it '一覧画面にメモ検索フォームが表示される' do
+      visit books_path
+
+      expect(page).to have_field('memo_keyword')
+      expect(page).to have_button('メモを検索')
+    end
+  end
+
+  describe 'メモ検索の実行' do
+    let!(:matching_memo) { create(:book_memo, book: book, content: '重要なポイントです') }
+    let!(:other_memo) { create(:book_memo, book: book, content: '別の内容') }
+
+    it 'キーワードで検索するとメモ一覧が表示される' do
+      visit books_path
+
+      fill_in 'memo_keyword', with: '重要'
+      click_button 'メモを検索'
+
+      expect(page).to have_content('重要なポイントです')
+      expect(page).not_to have_content('別の内容')
+    end
+
+    it 'メモ一覧にメモが属する本のタイトルが表示される' do
+      visit books_path
+
+      fill_in 'memo_keyword', with: '重要'
+      click_button 'メモを検索'
+
+      expect(page).to have_content(book.title)
+    end
+
+    it '検索結果が0件の場合は空メッセージが表示される' do
+      visit books_path
+
+      fill_in 'memo_keyword', with: '存在しないキーワード'
+      click_button 'メモを検索'
+
+      expect(page).to have_content('メモが見つかりません')
+    end
+
+    it 'クリアリンクをクリックすると本の一覧に戻る' do
+      visit books_path(memo_keyword: '重要')
+
+      expect(page).to have_css('#memo-search-clear')
+      find('#memo-search-clear').click
+
+      expect(current_path).to eq(books_path)
+      expect(page).to have_content(book.title)
+    end
+  end
+
+  describe 'アクセス制御' do
+    let!(:other_memo) { create(:book_memo, book: other_book, content: '他ユーザーの重要メモ') }
+
+    it '他ユーザーのメモは検索結果に含まれない' do
+      visit books_path
+
+      fill_in 'memo_keyword', with: '重要'
+      click_button 'メモを検索'
+
+      expect(page).not_to have_content('他ユーザーの重要メモ')
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #287 の対応です。
一覧画面にメモ検索フォームを追加し、キーワードでメモ本文を部分一致検索できるようにしました。
検索結果はメモの一覧形式で表示します（本の一覧ではなく）。

## 変更内容

- [x] `BookMemo` モデルに `content_like` スコープを追加（ILIKE 部分一致・`sanitize_sql_like` でSQLインジェクション対策）
- [x] `BooksController#index` に `memo_keyword` パラメータ対応を追加
- [x] `books/index.html.erb` にメモ検索フォームを追加
- [x] `books/_memo_search_results.html.erb` を新規作成（メモ一覧パーシャル）
- [x] `books.css` にメモ検索・メモ一覧のBEMスタイルを追加

## テスト

- [x] Model Specs: `BookMemo.content_like` スコープ（部分一致・大文字小文字区別なし・マッチなし）
- [x] Request Specs: メモ検索機能（認証・200応答・他ユーザーアクセス制御・空メッセージ・キーワード保持）
- [x] System Specs: メモ検索のE2Eフロー（フォーム表示・検索実行・クリア・アクセス制御）

## 検証結果

```
bundle exec rspec spec/models/book_memo_spec.rb spec/requests/books_index_spec.rb spec/system/books/memo_search_spec.rb
48 examples, 0 failures
```

```
bundle exec rubocop (変更ファイル対象)
5 files inspected, no offenses detected
```

## 関連Issue
Closes #287