### PR TITLE
#310 読了本の並び順を「読了日の新しい順（降順）」に変更

### DIFF
--- a/.steering/20260606-issue310-completed-books-sort-order/requirements.md
+++ b/.steering/20260606-issue310-completed-books-sort-order/requirements.md
@@ -1,0 +1,36 @@
+# Issue #310 要件
+
+## 概要
+
+読了した本の一覧において、並び順を「評価（星の数）順」から
+「読了日（`completed_at`）の新しい順（降順）」に変更する。
+
+## 期待される挙動
+
+- 読了した本の一覧画面において、直近で読了した本が一番上に表示される。
+- 過去に読了した本（読了日が古い本）ほど、一覧の下方に並ぶ。
+
+## 現状分析
+
+### 読了本の並び順を決めている箇所
+
+`app/models/book.rb` の `for_index_list` スコープ（L61-L66）:
+
+```ruby
+scope :for_index_list, lambda {
+  completed_val = statuses[:completed]
+  status_col = arel_table[:status]
+  ordering = Arel::Nodes::Case.new.when(status_col.eq(completed_val)).then(1).else(0)
+  order(ordering, :deadline)  # ← 読了本の二次ソートが :deadline になっている
+}
+```
+
+1次ソート: 未了本(0) → 読了本(1)  
+2次ソート: `deadline` 昇順（すべての本に適用）
+
+Issue #310 では、読了本グループの2次ソートを `completed_at: :desc` に変更する。
+
+## 変更対象
+
+- `app/models/book.rb`: `for_index_list` スコープのソート順修正
+- `spec/models/book_spec.rb`: 既存の `'読了済みの本が複数ある場合も期限順に並ぶ'` テストを更新

--- a/.steering/20260606-issue310-completed-books-sort-order/tasklist.md
+++ b/.steering/20260606-issue310-completed-books-sort-order/tasklist.md
@@ -1,0 +1,15 @@
+# タスクリスト: Issue #310 読了本の並び順変更
+
+## タスク
+
+- [x] ステアリングファイル作成（requirements.md, tasklist.md）
+- [ ] ブランチ作成: `feature/#310-completed-books-sort-by-completed-at`
+- [ ] `app/models/book.rb` の `for_index_list` スコープを修正
+- [ ] `spec/models/book_spec.rb` のテスト更新（読了本の並び順テスト修正＋新規ケース追加）
+- [ ] RSpec 実行・確認
+- [ ] RuboCop 実行・確認
+- [ ] コミット & プッシュ & PR作成
+
+## 振り返り
+
+（完了後に記載）

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -57,12 +57,22 @@ class Book < ApplicationRecord
     translator.to_s.split(/[,，]/).map(&:strip).reject(&:blank?)
   end
 
-  # 積読一覧用ソートスコープ：未了本を期限順 → 読了本を期限順
+  # 積読一覧用ソートスコープ：未了本を期限順 → 読了本を読了日の新しい順
   scope :for_index_list, lambda {
     completed_val = statuses[:completed]
     status_col = arel_table[:status]
-    ordering = Arel::Nodes::Case.new.when(status_col.eq(completed_val)).then(1).else(0)
-    order(ordering, :deadline)
+    deadline_col = arel_table[:deadline]
+    completed_at_col = arel_table[:completed_at]
+
+    # 1次ソート：未了本(0) → 読了本(1)
+    group_order = Arel::Nodes::Case.new.when(status_col.eq(completed_val)).then(1).else(0)
+
+    # 2次ソート：未了本は deadline 昇順、読了本は completed_at 降順のキーを CASE で切り替え
+    # 読了本には deadline を NULL 相当に、未了本には completed_at を NULL 相当にする
+    deadline_key = Arel::Nodes::Case.new.when(status_col.eq(completed_val)).then(nil).else(deadline_col)
+    completed_at_desc_key = Arel::Nodes::Case.new.when(status_col.eq(completed_val)).then(completed_at_col).else(nil)
+
+    order(group_order, deadline_key.asc.nulls_last, completed_at_desc_key.desc.nulls_last)
   }
 
   scope :title_like, ->(query) { where("title ILIKE ?", "%#{sanitize_sql_like(query)}%") }

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -541,15 +541,15 @@ RSpec.describe Book, type: :model do
       expect(result.first.id).to eq(book_unread.id)
     end
 
-    it '読了済みの本が複数ある場合も期限順に並ぶ' do
-      book_completed_far  = create(:book, user: user, deadline: Date.current + 20, status: :completed)
-      book_completed_near = create(:book, user: user, deadline: Date.current + 5, status: :completed)
+    it '読了済みの本が複数ある場合は読了日の新しい順に並ぶ' do
+      book_completed_old  = create(:book, user: user, status: :completed, completed_at: 10.days.ago)
+      book_completed_new  = create(:book, user: user, status: :completed, completed_at: 2.days.ago)
       book_unread         = create(:book, user: user, deadline: Date.current + 15, status: :unread)
 
       result = Book.where(user: user).for_index_list
       expect(result.first.id).to eq(book_unread.id)
-      expect(result.second.id).to eq(book_completed_near.id)
-      expect(result.last.id).to eq(book_completed_far.id)
+      expect(result.second.id).to eq(book_completed_new.id)
+      expect(result.last.id).to eq(book_completed_old.id)
     end
   end
 


### PR DESCRIPTION
## 概要

Issue #310 の対応。

読了した本の一覧における並び順を、「期限（deadline）昇順」から「読了日（completed_at）降順（新しい順）」に変更しました。

## 変更内容

### `app/models/book.rb`

`for_index_list` スコープの二次ソートを変更:

- **変更前**: 全本（未了・読了）を `deadline` 昇順でソート
- **変更後**: 未了本は `deadline` 昇順、読了本は `completed_at` 降順でソート

Arel の `CASE WHEN` を用いて、読了本グループのみに `completed_at DESC` を適用し、未了本グループはこれまで通り `deadline ASC` を維持しています。

### `spec/models/book_spec.rb`

`.for_index_list` のテストケースを更新:

- 「読了済みの本が複数ある場合も期限順に並ぶ」→「読了済みの本が複数ある場合は読了日の新しい順に並ぶ」に変更

## 検証

- `bundle exec rspec spec/models/book_spec.rb` → 117 examples, 0 failures ✅
- `bundle exec rubocop app/models/book.rb spec/models/book_spec.rb` → no offenses ✅

Closes #310