### PR TITLE
#321 過去のメモ・評価・感想のランダム振り返り機能の実装

### DIFF
--- a/app/assets/stylesheets/dashboards.css
+++ b/app/assets/stylesheets/dashboards.css
@@ -565,3 +565,160 @@
     top: -14px;
   }
 }
+
+/* ---- 過去のランダム振り返り (Lookback Card) ---- */
+.lookback-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  background-color: var(--color-bg-surface);
+}
+
+.lookback-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-xs);
+}
+
+.lookback-card__title {
+  margin-bottom: 0;
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.lookback-card__shuffle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 4px 8px;
+  text-decoration: none;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+  cursor: pointer;
+}
+
+.lookback-card__shuffle:hover {
+  background-color: var(--color-bg-surface);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.lookback-card__shuffle-icon {
+  font-size: 0.9rem;
+}
+
+.lookback-card__book-info {
+  margin-bottom: var(--spacing-xs);
+  padding: var(--spacing-xs) 0;
+}
+
+.lookback-card__book-title {
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  margin-bottom: 2px;
+  line-height: 1.4;
+}
+
+.lookback-card__book-title a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.lookback-card__book-title a:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.lookback-card__book-author {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.lookback-card__section {
+  border-radius: var(--border-radius);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-top: var(--spacing-xs);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.02);
+}
+
+/* 本全体の評価と感想枠 (マクロ視点) */
+.lookback-card__section--review {
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+}
+
+/* 読書中のメモ枠 (ミクロ視点) */
+.lookback-card__section--memo {
+  background-color: var(--color-bg-surface);
+  border: 1px dashed var(--color-secondary);
+}
+
+.lookback-card__section-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-secondary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.lookback-card__rating {
+  margin-bottom: var(--spacing-xs);
+}
+
+.lookback-card__stars {
+  color: #d97706;
+  font-size: 12px;
+  letter-spacing: 1px;
+}
+
+.lookback-card__no-rating {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.lookback-card__review {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+.lookback-card__review p {
+  margin-bottom: 0;
+}
+
+.lookback-card__no-review {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
+.lookback-card__memo-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.lookback-card__memo-content {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.lookback-card__memo-content p {
+  margin-bottom: 0;
+}
+
+.lookback-card__memo-page {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  align-self: flex-end;
+  font-style: normal;
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -21,6 +21,13 @@ class DashboardsController < ApplicationController
 
     # 週次アクティビティ (過去7日間の日別読了ページ数)
     @weekly_activity = calculate_weekly_activity
+
+    set_random_lookback
+  end
+
+  def lookback
+    set_random_lookback
+    render partial: "dashboards/random_lookback", locals: { random_book: @random_book, random_memo: @random_memo }
   end
 
   private
@@ -61,5 +68,12 @@ class DashboardsController < ApplicationController
                       .group(:read_at)
                       .sum(:pages_read)
     (start_date..Date.current).map { |date| [ date, logs[date] || 0 ] }
+  end
+
+  def set_random_lookback
+    @random_book = current_user.books.completed.order("RANDOM()").first
+    if @random_book
+      @random_memo = @random_book.book_memos.order("RANDOM()").first
+    end
   end
 end

--- a/app/views/dashboards/_random_lookback.html.erb
+++ b/app/views/dashboards/_random_lookback.html.erb
@@ -1,0 +1,61 @@
+<%= turbo_frame_tag "random-lookback" do %>
+  <% if random_book %>
+    <section class="dashboard__card lookback-card" aria-label="<%= t('dashboards.lookback.lookback_title') %>">
+      <div class="lookback-card__header">
+        <h2 class="lookback-card__title">
+          <%= t('dashboards.lookback.lookback_title') %>
+        </h2>
+        <%= link_to lookback_dashboard_path, class: "lookback-card__shuffle", data: { turbo_frame: "random-lookback" }, aria: { label: t('dashboards.lookback.shuffle_btn') } do %>
+          <span class="lookback-card__shuffle-icon" aria-hidden="true">🔄</span>
+          <span class="lookback-card__shuffle-text"><%= t('dashboards.lookback.shuffle_btn') %></span>
+        <% end %>
+      </div>
+
+      <div class="lookback-card__book-info">
+        <h3 class="lookback-card__book-title">
+          <%= link_to random_book.title, book_path(random_book), data: { turbo: false } %>
+        </h3>
+        <% if random_book.author.present? %>
+          <p class="lookback-card__book-author"><%= random_book.author %></p>
+        <% end %>
+      </div>
+
+      <div class="lookback-card__section lookback-card__section--review">
+        <h4 class="lookback-card__section-title"><%= t('dashboards.lookback.overall_review') %></h4>
+        
+        <div class="lookback-card__rating" aria-label="評価: <%= random_book.rating || 0 %> / 5">
+          <% if random_book.rating.present? %>
+            <span class="lookback-card__stars"><%= "★" * random_book.rating %><%= "☆" * (5 - random_book.rating) %></span>
+          <% else %>
+            <span class="lookback-card__no-rating"><%= t('dashboards.lookback.no_rating') %></span>
+          <% end %>
+        </div>
+
+        <div class="lookback-card__review">
+          <% if random_book.review.present? %>
+            <%= simple_format(random_book.review) %>
+          <% else %>
+            <p class="lookback-card__no-review"><%= t('dashboards.lookback.no_review') %></p>
+          <% end %>
+        </div>
+      </div>
+
+      <% if random_memo %>
+        <div class="lookback-card__section lookback-card__section--memo">
+          <h4 class="lookback-card__section-title"><%= t('dashboards.lookback.reading_memos') %></h4>
+          
+          <div class="lookback-card__memo-body">
+            <blockquote class="lookback-card__memo-content">
+              <%= simple_format(random_memo.content) %>
+            </blockquote>
+            <% if random_memo.page_number.present? %>
+              <cite class="lookback-card__memo-page">
+                p. <%= random_memo.page_number %>
+              </cite>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </section>
+  <% end %>
+<% end %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -172,6 +172,9 @@
         </div>
       </section>
 
+      <!-- 過去の振り返り（ランダムピックアップ） -->
+      <%= render "dashboards/random_lookback", random_book: @random_book, random_memo: @random_memo %>
+
       <!-- 最近読了した本 (Recently Finished) -->
       <section class="dashboard__card dashboard__completed">
         <h2 class="dashboard__card-title"><%= t('.recently_finished') %></h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,3 +28,11 @@ en:
       recently_finished: "Recently Finished"
       no_completed_books: "No recently finished books."
       add_book: "Add Book"
+    lookback:
+      lookback_title: "Past Reading Lookback"
+      shuffle_btn: "Shuffle"
+      overall_review: "【Overall Review】"
+      reading_memos: "【Reading Memos】"
+      no_rating: "No Rating"
+      no_review: "(No review written)"
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -84,3 +84,11 @@ ja:
       recently_finished: "最近読了した本"
       no_completed_books: "最近読了した本はありません。"
       add_book: "本を登録"
+    lookback:
+      lookback_title: "過去の読書からの発掘"
+      shuffle_btn: "別の本"
+      overall_review: "【全体の感想】"
+      reading_memos: "【読書中のメモ】"
+      no_rating: "評価なし"
+      no_review: "（感想はありません）"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
   }
   root "top#index"
 
-  resource :dashboard, only: [ :show ]
+  resource :dashboard, only: [ :show ] do
+    get :lookback
+  end
   resource :mypage, only: [ :show, :update ] do
     get :stats
   end

--- a/spec/requests/dashboards_spec.rb
+++ b/spec/requests/dashboards_spec.rb
@@ -84,4 +84,52 @@ RSpec.describe 'Dashboards', type: :request do
       end
     end
   end
+
+  describe 'GET /dashboard/lookback' do
+    context '未ログインの場合' do
+      it 'ログイン画面へリダイレクトされる' do
+        get lookback_dashboard_path
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'ログイン済みの場合' do
+      before { sign_in user }
+
+      context '読了済みの本が存在しない場合' do
+        it '200 OK を返し、ランダム振り返りカードが表示されないこと' do
+          get lookback_dashboard_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).not_to include('lookback-card')
+        end
+      end
+
+      context '読了済みの本が存在する場合' do
+        let!(:completed_book) { create(:book, user: user, status: :completed, title: '読了本タイトル', rating: 4, review: 'とても面白かった。') }
+
+        it '200 OK を返し、ランダム振り返りカードに書籍タイトルや感想・評価が表示されること' do
+          get lookback_dashboard_path
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include('lookback-card')
+          expect(response.body).to include('読了本タイトル')
+          expect(response.body).to include('★★★★☆')
+          expect(response.body).to include('とても面白かった。')
+        end
+
+        context 'メモも存在する場合' do
+          let!(:book_memo) { create(:book_memo, book: completed_book, content: '感銘を受けたメモ', page_number: '123') }
+
+          it 'メモの内容やページ番号が表示されること' do
+            get lookback_dashboard_path
+
+            expect(response.body).to include('感銘を受けたメモ')
+            expect(response.body).to include('p. 123')
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/system/dashboards_spec.rb
+++ b/spec/system/dashboards_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe 'ダッシュボード', type: :system do
         expect(page).to have_text('読了テスト本')
         expect(page).to have_text('★★★★★')
       end
+
+      it '過去の振り返り（ランダム振り返り）セクションが表示され、シャッフル動作が機能すること' do
+        completed_book1 = create(:book, user: user, status: :completed, title: '過去の読了本A', rating: 4, review: 'Aの感想', completed_at: Date.current)
+        create(:book_memo, book: completed_book1, content: 'Aのメモ', page_number: '10')
+
+        completed_book2 = create(:book, user: user, status: :completed, title: '過去の読了本B', rating: 5, review: 'Bの感想', completed_at: Date.current)
+        create(:book_memo, book: completed_book2, content: 'Bのメモ', page_number: '20')
+
+        visit dashboard_path
+
+        expect(page).to have_text(I18n.t('dashboards.lookback.lookback_title'))
+        expect(page).to have_css('.lookback-card')
+        expect(page).to have_link('別の本')
+
+        # シャッフルリンクのクリック
+        click_link '別の本'
+        expect(page).to have_css('.lookback-card')
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要
過去に読了した本からランダムに1冊をピックアップし、その評価・感想と読書中のメモをダッシュボード上で振り返る機能を実装しました。

## 変更内容
- dashboards#lookback のルーティングとアクションを新設し、Turbo Frameを用いた非同期シャッフル機能を実装しました。
- 評価・感想枠と読書中のメモ枠を視覚的に分けたデザインの lookback-card をダッシュボードのサイドバーに追加しました。
- 日本語/英語の翻訳定義を追加しました。
- 新設したアクションおよびビュー、シャッフル挙動のテスト（RSpec）を追加しました。

## 検証結果
- RSpec の Request spec および System spec が全てパスすることを確認済みです。
- RuboCop にて警告が出ないことを確認済みです。

Closes #321