### PR TITLE
#327 過去に読んだ本を登録した際に読書ログを自動作成する

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -35,6 +35,7 @@ class Book < ApplicationRecord
 
   before_save :auto_set_reading_status
   before_save :apply_past_reading_settings
+  after_create :create_reading_log_for_past_reading, if: :completed?
 
   def extend_deadline!(new_deadline)
     return false if new_deadline.blank?
@@ -238,5 +239,14 @@ class Book < ApplicationRecord
     return if current_page.to_i.zero?
 
     self.status = :reading
+  end
+
+  def create_reading_log_for_past_reading
+    reading_logs.create!(
+      pages_read: pages,
+      read_at: completed_at&.to_date || Date.current,
+      start_page: 1,
+      end_page: pages
+    )
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -35,7 +35,7 @@ class Book < ApplicationRecord
 
   before_save :auto_set_reading_status
   before_save :apply_past_reading_settings
-  after_create :create_reading_log_for_past_reading, if: :completed?
+  after_create :create_reading_log_for_past_reading, if: :past_reading_checked?
 
   def extend_deadline!(new_deadline)
     return false if new_deadline.blank?

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -667,6 +667,28 @@ RSpec.describe Book, type: :model do
         end
       end
     end
+
+    describe '#create_reading_log_for_past_reading (after_create)' do
+      context 'ステータスが completed（読了）で新規作成された場合' do
+        it '全ページ分の読書ログ（ReadingLog）が自動で作成されること' do
+          book = build(:book, pages: 300, is_past_reading: 'true', completed_at_input: '2026-06-01')
+          expect { book.save! }.to change(ReadingLog, :count).by(1)
+
+          log = book.reading_logs.last
+          expect(log.pages_read).to eq(300)
+          expect(log.read_at).to eq(Date.parse('2026-06-01'))
+          expect(log.start_page).to eq(1)
+          expect(log.end_page).to eq(300)
+        end
+      end
+
+      context 'ステータスが completed 以外（unreadなど）で新規作成された場合' do
+        it '読書ログは作成されないこと' do
+          book = build(:book, pages: 300, is_past_reading: 'false', status: :unread)
+          expect { book.save! }.not_to change(ReadingLog, :count)
+        end
+      end
+    end
   end
 
   describe 'ビジネスロジック' do

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -669,7 +669,7 @@ RSpec.describe Book, type: :model do
     end
 
     describe '#create_reading_log_for_past_reading (after_create)' do
-      context 'ステータスが completed（読了）で新規作成された場合' do
+      context '過去読書チェックを有効にして新規作成された場合' do
         it '全ページ分の読書ログ（ReadingLog）が自動で作成されること' do
           book = build(:book, pages: 300, is_past_reading: 'true', completed_at_input: '2026-06-01')
           expect { book.save! }.to change(ReadingLog, :count).by(1)
@@ -679,6 +679,13 @@ RSpec.describe Book, type: :model do
           expect(log.read_at).to eq(Date.parse('2026-06-01'))
           expect(log.start_page).to eq(1)
           expect(log.end_page).to eq(300)
+        end
+      end
+
+      context '過去読書チェックを無効にして新規作成された場合（通常の読了本データ作成など）' do
+        it '読書ログは作成されないこと' do
+          book = build(:book, pages: 300, is_past_reading: 'false', status: :completed)
+          expect { book.save! }.not_to change(ReadingLog, :count)
         end
       end
 

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -545,10 +545,14 @@ RSpec.describe 'Books', type: :request do
           }
         end
 
-        it '書籍が作成される' do
+        it '書籍と読書ログが作成される' do
           expect {
             post books_path, params: past_reading_with_date_params
-          }.to change(Book, :count).by(1)
+          }.to change(Book, :count).by(1).and change(ReadingLog, :count).by(1)
+
+          log = ReadingLog.last
+          expect(log.pages_read).to eq(300)
+          expect(log.read_at).to eq(Date.current - 5)
         end
 
         it '書籍が completed ステータスで作成される' do
@@ -590,10 +594,14 @@ RSpec.describe 'Books', type: :request do
           }
         end
 
-        it '書籍が作成される' do
+        it '書籍と読書ログが作成される' do
           expect {
             post books_path, params: past_reading_without_date_params
-          }.to change(Book, :count).by(1)
+          }.to change(Book, :count).by(1).and change(ReadingLog, :count).by(1)
+
+          log = ReadingLog.last
+          expect(log.pages_read).to eq(200)
+          expect(log.read_at).to eq(Date.current)
         end
 
         it '書籍が completed ステータスで作成される' do


### PR DESCRIPTION
## 概要
過去に読んだ本として登録（is_past_reading）した際に読書ログ（ReadingLog）が作成されず、ダッシュボードの総ページ数に反映されない不具合を修正しました。

## 変更内容
- Book モデルに after_create コールバックを追加し、書籍の status が completed（読了）で新規作成された場合に ReadingLog を自動作成するようにしました。
- 単体テスト（spec/models/book_spec.rb）にコールバックのテストケースを追加しました。
- 統合テスト（spec/requests/books_spec.rb）の is_past_reading テストケースで ReadingLog が作成されていることを検証するアサーションを追加しました。

## テスト
- Model Specs: spec/models/book_spec.rb (コールバックの動作検証)
- Request Specs: spec/requests/books_spec.rb (過去読書登録時のログ作成検証)

## 関連Issue
Closes #327