### PR TITLE
chore: プロジェクト自動化ワークフローからIssue作成時の自動追加ジョブを削除

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,26 +1,10 @@
 name: Project Automation
 
 on:
-  issues:
-    types: [opened, reopened]
   pull_request:
     types: [closed]
 
 jobs:
-  # ─────────────────────────────────────────
-  # Issue/PR がプロジェクトに未登録の場合に自動追加
-  # ─────────────────────────────────────────
-  add_to_project:
-    name: Add to GitHub Project
-    runs-on: ubuntu-latest
-    if: github.event.action == 'opened' || github.event.action == 'reopened'
-
-    steps:
-      - uses: actions/add-to-project@v1.0.2
-        with:
-          project-url: https://github.com/users/liverpl1920/projects/2
-          github-token: ${{ secrets.PROJECT_TOKEN }}
-
   # ─────────────────────────────────────────
   # PR マージ時: linked issue を "Done" へ移動
   # ─────────────────────────────────────────

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -347,7 +347,7 @@ services:
 
 ## ステップ 4: GitHub Project の自動化
 
-### Issue 作成/再オープン時の自動追加 + PRマージ時のDone移動
+### PRマージ時のDone移動
 
 ```yaml
 # .github/workflows/project-automation.yml
@@ -355,22 +355,10 @@ services:
 name: Project Automation
 
 on:
-  issues:
-    types: [opened, reopened]
   pull_request:
     types: [closed]
 
 jobs:
-  # Issue 作成時/再オープン時 → プロジェクトに追加
-  add-to-project:
-    if: github.event.action == 'opened' || github.event.action == 'reopened'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v1.0.2
-        with:
-          project-url: https://github.com/users/liverpl1920/projects/2
-          github-token: ${{ secrets.PROJECT_TOKEN }}
-
   # PR close かつ merge=true のときに linked issue を Done に移動
   move-to-done:
     if: >
@@ -383,7 +371,6 @@ jobs:
 運用ルール:
 
 - PR 作成時（opened）には Project Automation は実行されません。
-- Issue の opened/reopened ではプロジェクトへ自動追加されます。
 - PR が merged されたときのみ linked issue の Done 移動処理が実行されます。
 
 ### PR テンプレートの設定


### PR DESCRIPTION
## 概要

プロジェクト自動化ワークフローから、Issue作成時にプロジェクトへ自動追加するジョブを削除しました。

## 対応 Issue

なし（自動エラー通知を止めるためのメンテナンス）

## 実装内容

- [x] `.github/workflows/project-automation.yml` から `add_to_project` ジョブおよびトリガーイベントを削除
- [x] `docs/development-workflow.md` の該当する説明を更新

## 動作確認

- [x] ローカルで差分およびマークダウンドキュメントの構文確認済み
